### PR TITLE
Fix Doxygen workflow to clone submodules

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -13,8 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Generate
-        uses: mattnotmitt/doxygen-action@v1.9.5
+        uses: mattnotmitt/doxygen-action@v1.9.4
         with:
           enable-latex: false
       - name: Deploy to pages

--- a/Doxyfile
+++ b/Doxyfile
@@ -944,7 +944,6 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = src README.md
-INPUT                 += src/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Doyxgen generation workflow now clones submodules to properly include the doxygen-awesome CSS.