### PR TITLE
EEPROM board IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ Pressure: 99.94 kPa
 
 All sensor data output is printed in plain-text, with its type specifier (i.e. temperature), its value and its unit.
 
+## Board ID EEPROM Encoding
+
+In order for fetcher to recognize the sensors on the board, the EEPROM must encode the ID in this format:
+
+```
+CU InSpace <board name> REV <x>: <manufacture date>
+<sensor 1 id> <address>
+<sensor 2 id> <address>
+```
+
+**Fields:**
+
+- `<board name>`: The name of the board. Ex: `Sensor board`
+- `REV <x>`: The revision of the board. Ex: `REV B`
+- `<sensor id>`: The identifier of the sensor. Ex: `MS5611`
+- `<address>`: The 7 bit I2C address of the sensor in hexadecimal (without the leading 0x). Ex: `77`
+
 <!--- Links --->
 
 [packager]: https://github.com/CarletonURocketry/packager

--- a/src/eeprom/eeprom.c
+++ b/src/eeprom/eeprom.c
@@ -1,0 +1,56 @@
+#include "eeprom.h"
+#include <hw/i2c.h>
+#include <string.h>
+
+/** The address of the EEPROM on the I2C bus. */
+#define EEPROM_ADDR 0x50
+
+/** Address for reading the EEPROM. */
+#define EEPROM_READ (EEPROM_ADDR | 0x1)
+
+/** Address for writing to the EEPROM. */
+#define EEPROM_WRITE (EEPROM_ADDR & 0xFE)
+
+/** The maximum capacity of the EEPROM in bytes. */
+#define EEPROM_CAP 128
+
+/** Defines a small buffer for the dummy write request. */
+struct dummy_write_t {
+    i2c_send_t header;    /**< The send header containing address information. */
+    uint8_t byte_address; /** The byte address for beginning the read. */
+};
+
+/**
+ * Read `n` bytes from the EEPROM into a buffer.
+ * @param addr The address to start the read from.
+ * @param bus The I2C bus where the EEPROM is located.
+ * @param buf A pointer to the buffer to store the data that will be read. Must have space for `n` + 20 bytes.
+ * @param n The number of bytes to read from the EEPROM.
+ */
+errno_t eeprom_read(uint8_t addr, int bus, void *buf, size_t n) {
+
+    // Dummy write to start from address
+    static struct dummy_write_t dummy_write = {
+        .header =
+            {
+                .stop = 0,
+                .len = 1,
+                .slave = {.fmt = I2C_ADDRFMT_7BIT, .addr = EEPROM_WRITE},
+            },
+    };
+    dummy_write.byte_address = addr;
+    errno_t err = devctl(bus, DCMD_I2C_SEND, &dummy_write, sizeof(dummy_write), NULL);
+    if (err != EOK) return err;
+
+    // Start sequential read into buffer
+    i2c_sendrecv_t read_header = {
+        .stop = 1,
+        .send_len = 0,
+        .recv_len = n,
+        .slave = {.fmt = I2C_ADDRFMT_7BIT, .addr = EEPROM_WRITE},
+    };
+    memcpy(buf, &read_header, sizeof(read_header));
+    err = devctl(bus, DCMD_I2C_SENDRECV, &((uint8_t *)(buf))[sizeof(read_header)], n, NULL);
+    if (err != EOK) return err;
+    return EOK;
+}

--- a/src/eeprom/eeprom.h
+++ b/src/eeprom/eeprom.h
@@ -1,0 +1,10 @@
+#ifndef _M24C02_EEPROM_H
+#define _M24C02_EEPROM_H
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+
+errno_t eeprom_read(uint8_t addr, int bus, void *buf, size_t n);
+
+#endif // _M24C02_EEPROM_H

--- a/src/eeprom/eeprom.h
+++ b/src/eeprom/eeprom.h
@@ -1,10 +1,14 @@
 #ifndef _M24C02_EEPROM_H
 #define _M24C02_EEPROM_H
 
-#include <stdlib.h>
-#include <stdint.h>
 #include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/** The maximum capacity of the EEPROM in bytes. */
+#define EEPROM_CAP 128
 
 errno_t eeprom_read(uint8_t addr, int bus, void *buf, size_t n);
+const uint8_t *eeprom_contents(int bus);
 
 #endif // _M24C02_EEPROM_H

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,7 @@
  *
  * The main function for the fetcher module, where program logic is used to create a console application.
  */
+#include "eeprom/eeprom.h"
 #include "sensors/sensor_api.h"
 #include <devctl.h>
 #include <errno.h>
@@ -69,6 +70,12 @@ int main(int argc, char **argv) {
     if (bus_speed != EOK) {
         fprintf(stderr, "Failed to set bus speed to %u with error %s\n", speed, strerror(bus_speed));
         exit(EXIT_FAILURE);
+    }
+
+    /* Print out the board ID EEPROM contents. */
+    uint8_t const *board_id = eeprom_contents(bus);
+    for (uint16_t i = 0; i < EEPROM_CAP; i++) {
+        putchar(board_id[i]);
     }
 
     /* Create sensor list. */

--- a/src/main.c
+++ b/src/main.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     Sensor sensors[2];
 
     // Create MS5611 instance
-    ms5611_init(&sensors[0], bus, 0x76, PRECISION_HIGH);
+    ms5611_init(&sensors[0], bus, 0x77, PRECISION_HIGH);
 
     uint8_t ms5611_context[sensor_get_ctx_size(sensors[0])];
     sensor_set_ctx(&sensors[0], ms5611_context);

--- a/src/main.c
+++ b/src/main.c
@@ -74,9 +74,6 @@ int main(int argc, char **argv) {
 
     /* Print out the board ID EEPROM contents. */
     uint8_t const *board_id = eeprom_contents(bus);
-    for (uint16_t i = 0; i < EEPROM_CAP; i++) {
-        putchar(board_id[i]);
-    }
 
     /* Create sensor list. */
     Sensor sensors[2];


### PR DESCRIPTION
Fetcher now has the capability to read the board IDs into memory before startup! This means that we can programmatically configure which drivers we use.