### PR TITLE
I2C lock

### DIFF
--- a/src/sensors/lsm6dso32/lsm6dso32.c
+++ b/src/sensors/lsm6dso32/lsm6dso32.c
@@ -156,7 +156,7 @@ static errno_t lsm6dso32_read(Sensor *sensor, const SensorTag tag, void *buf, si
         return_err(err);
         devctl(sensor->loc.bus, DCMD_I2C_UNLOCK, NULL, 0, NULL); // Unlock bus
 
-        *(float *)buf = (float)(temp) / 256.0f + 25.0f;          // In degrees Celsius
+        *(float *)buf = (float)(temp) / 256.0f + 25.0f; // In degrees Celsius
         *nbytes = sizeof(float);
         break;
     }

--- a/src/sensors/ms5611/ms5611.c
+++ b/src/sensors/ms5611/ms5611.c
@@ -160,7 +160,7 @@ static errno_t ms5611_read_dreg(SensorLocation *loc, uint8_t dreg, uint32_t *val
     }
 
     // Unlock I2C bus
-    err = devctl(loc->bus, DCMD_I2C_LOCK, NULL, 0, NULL);
+    err = devctl(loc->bus, DCMD_I2C_UNLOCK, NULL, 0, NULL);
 
     *value = 0;
     *value += read_cmd[sizeof(read)] * 65536;


### PR DESCRIPTION
This PR implements the locking and unlocking of the I2C bus mutex to allow for the eventual implementation of multi-threading.

Certain functions in the sensor drivers that use the I2C bus do not lock it, simply because they are functions that are meant to be called in sequence or multiple times (i.e. multiple calls to read byte for extracting data). These functions are marked with `WARNING` in their docstrings so that callers are aware that they must lock the I2C bus before performing a collection of these calls. This reduces overhead.