### PR TITLE
Message queues

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -21,7 +21,7 @@ OPTIMIZATION = -O2
 # (see https://gcc.gnu.org/onlinedocs/gcc-6.3.0/gcc/Warning-Options.html)
 WARNINGS += -Wall -Wextra -Wshadow -Wundef -Wformat=2 -Wtrampolines -Wfloat-equal
 WARNINGS += -Wbad-function-cast -Wstrict-prototypes -Wpacked
-WARNINGS += -Wno-aggressive-loop-optimizations -Wmissing-prototypes -Winit-self
+WARNINGS += -Wno-aggressive-loop-optimizations -Winit-self -Wmissing-declarations
 WARNINGS += -Wmissing-format-attribute -Wunreachable-code
 WARNINGS += -Wshift-overflow=2 -Wduplicated-cond -Wpointer-arith -Wwrite-strings
 WARNINGS += -Wnested-externs -Wcast-align -Wredundant-decls

--- a/src/collectors/collectors.h
+++ b/src/collectors/collectors.h
@@ -7,6 +7,9 @@
 #include <stdio.h>
 #include <string.h>
 
+/** The name of the message queue to be used for sensors to write their data. */
+#define SENSOR_QUEUE "fetcher/sensors"
+
 /** Macro for dereferencing the collector argument. */
 #define clctr_args(args) ((collector_args_t *)((args)))
 

--- a/src/collectors/lsm6dso32_clctr.c
+++ b/src/collectors/lsm6dso32_clctr.c
@@ -1,10 +1,19 @@
 #include "../drivers/lsm6dso32/lsm6dso32.h"
 #include "collectors.h"
 #include "sensor_api.h"
+#include <stdio.h>
 
 void *lsm6dso32_collector(void *args) {
 
-    // Create LSM6DO32 instance
+    /* Open message queue. */
+    mqd_t sensor_q = mq_open(SENSOR_QUEUE, O_WRONLY);
+    if (sensor_q == -1) {
+        fprintf(stderr, "LSM6DSO32 collector could not open message queue '%s': '%s' \n", SENSOR_QUEUE,
+                strerror(errno));
+        return (void *)((uint64_t)errno);
+    }
+
+    /* Create LSM6DO32 instance */
     Sensor lsm6dso32;
     lsm6dso32_init(&lsm6dso32, clctr_args(args)->bus, clctr_args(args)->addr, PRECISION_HIGH);
 
@@ -13,21 +22,33 @@ void *lsm6dso32_collector(void *args) {
     errno_t err = sensor_open(lsm6dso32);
     if (err != EOK) {
         fprintf(stderr, "%s\n", strerror(err));
-        return (void *)err;
+        return (void *)((uint64_t)err);
     }
 
     size_t nbytes;
-    float temperature;
-    vec3d_t vector_data;
+    uint8_t data[sensor_max_dsize(&lsm6dso32) + 1];
+
     for (;;) {
+
         // Read temperature
-        sensor_read(lsm6dso32, TAG_TEMPERATURE, &temperature, &nbytes);
-        sensor_write_data(stdout, TAG_TEMPERATURE, &temperature);
+        sensor_read(lsm6dso32, TAG_TEMPERATURE, &data[1], &nbytes);
+        data[0] = TAG_TEMPERATURE;
+        if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
+            fprintf(stderr, "LSM6DSO32 couldn't send message: %s\n", strerror(errno));
+        }
+
         // Read linear acceleration
-        sensor_read(lsm6dso32, TAG_LINEAR_ACCEL, &vector_data, &nbytes);
-        sensor_write_data(stdout, TAG_LINEAR_ACCEL, &vector_data);
+        sensor_read(lsm6dso32, TAG_LINEAR_ACCEL, &data[1], &nbytes);
+        data[0] = TAG_LINEAR_ACCEL;
+        if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
+            fprintf(stderr, "LSM6DSO32 couldn't send message: %s\n", strerror(errno));
+        }
+
         // Read angular velocity
-        sensor_read(lsm6dso32, TAG_ANGULAR_VEL, &vector_data, &nbytes);
-        sensor_write_data(stdout, TAG_ANGULAR_VEL, &vector_data);
+        sensor_read(lsm6dso32, TAG_ANGULAR_VEL, &data[1], &nbytes);
+        data[0] = TAG_ANGULAR_VEL;
+        if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
+            fprintf(stderr, "LSM6DSO32 couldn't send message: %s\n", strerror(errno));
+        }
     }
 }

--- a/src/collectors/ms5611_clctr.c
+++ b/src/collectors/ms5611_clctr.c
@@ -30,11 +30,15 @@ void *ms5611_collector(void *args) {
         // Read pressure
         sensor_read(ms5611, TAG_PRESSURE, &data[1], &nbytes);
         data[0] = TAG_PRESSURE;
-        mq_send(sensor_q, (char *)data, sizeof(data), 0);
+        if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
+            fprintf(stderr, "MS5611 couldn't send message: %s.\n", strerror(errno));
+        }
 
         // Read temperature
         sensor_read(ms5611, TAG_TEMPERATURE, &data[1], &nbytes);
         data[0] = TAG_TEMPERATURE;
-        mq_send(sensor_q, (char *)data, sizeof(data), 0);
+        if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
+            fprintf(stderr, "MS5611 couldn't send message: %s.\n", strerror(errno));
+        }
     }
 }

--- a/src/collectors/ms5611_clctr.c
+++ b/src/collectors/ms5611_clctr.c
@@ -4,7 +4,14 @@
 
 void *ms5611_collector(void *args) {
 
-    // Create MS5611 instance
+    /* Open message queue. */
+    mqd_t sensor_q = mq_open(SENSOR_QUEUE, O_WRONLY);
+    if (sensor_q == -1) {
+        fprintf(stderr, "SHT41 collector could not open message queue '%s': '%s' \n", SENSOR_QUEUE, strerror(errno));
+        return (void *)((uint64_t)errno);
+    }
+
+    /* Create MS5611 instance */
     Sensor ms5611;
     ms5611_init(&ms5611, clctr_args(args)->bus, clctr_args(args)->addr, PRECISION_HIGH);
     uint8_t ms5611_context[sensor_get_ctx_size(ms5611)];
@@ -12,19 +19,22 @@ void *ms5611_collector(void *args) {
     errno_t err = sensor_open(ms5611);
     if (err != EOK) {
         fprintf(stderr, "%s\n", strerror(err));
-        return (void *)err;
+        return (void *)((uint64_t)err);
     }
 
-    float data;
+    uint8_t data[sensor_max_dsize(&ms5611) + 1];
     size_t nbytes;
+
     for (;;) {
 
-        // Print pressure
-        sensor_read(ms5611, TAG_PRESSURE, &data, &nbytes);
-        sensor_write_data(stdout, TAG_PRESSURE, &data);
+        // Read pressure
+        sensor_read(ms5611, TAG_PRESSURE, &data[1], &nbytes);
+        data[0] = TAG_PRESSURE;
+        mq_send(sensor_q, (char *)data, sizeof(data), 0);
 
-        // Print temperature
-        sensor_read(ms5611, TAG_TEMPERATURE, &data, &nbytes);
-        sensor_write_data(stdout, TAG_TEMPERATURE, &data);
+        // Read temperature
+        sensor_read(ms5611, TAG_TEMPERATURE, &data[1], &nbytes);
+        data[0] = TAG_TEMPERATURE;
+        mq_send(sensor_q, (char *)data, sizeof(data), 0);
     }
 }

--- a/src/collectors/ms5611_clctr.c
+++ b/src/collectors/ms5611_clctr.c
@@ -7,7 +7,7 @@ void *ms5611_collector(void *args) {
     /* Open message queue. */
     mqd_t sensor_q = mq_open(SENSOR_QUEUE, O_WRONLY);
     if (sensor_q == -1) {
-        fprintf(stderr, "SHT41 collector could not open message queue '%s': '%s' \n", SENSOR_QUEUE, strerror(errno));
+        fprintf(stderr, "MS5611 collector could not open message queue '%s': '%s' \n", SENSOR_QUEUE, strerror(errno));
         return (void *)((uint64_t)errno);
     }
 

--- a/src/collectors/sht41_clctr.c
+++ b/src/collectors/sht41_clctr.c
@@ -35,11 +35,15 @@ void *sht41_collector(void *args) {
         // Read temperature
         sensor_read(sht41, TAG_TEMPERATURE, &data[1], &nbytes);
         data[0] = TAG_TEMPERATURE;
-        mq_send(sensor_q, (char *)data, sizeof(data), 0);
+        if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
+            fprintf(stderr, "SHT41 couldn't send message: %s\n", strerror(errno));
+        }
 
         // Read humidity
         sensor_read(sht41, TAG_HUMIDITY, &data[1], &nbytes);
         data[0] = TAG_HUMIDITY;
-        mq_send(sensor_q, (char *)data, sizeof(data), 0);
+        if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
+            fprintf(stderr, "SHT41 couldn't send message: %s\n", strerror(errno));
+        }
     }
 }

--- a/src/collectors/sysclock_clctr.c
+++ b/src/collectors/sysclock_clctr.c
@@ -1,9 +1,14 @@
 #include "../drivers/sysclock/sysclock.h"
 #include "collectors.h"
+#include <stdio.h>
+#include <time.h>
 
 void *sysclock_collector(void *args) {
 
-    // Create system clock instance
+    /* Open message queue to send data. */
+    mqd_t sensor_q = mq_open(SENSOR_QUEUE, O_WRONLY);
+
+    /* Create system clock instance. */
     Sensor clock;
     sysclock_init(&clock, clctr_args(args)->bus, clctr_args(args)->addr, PRECISION_HIGH);
     uint8_t sysclock_context[sensor_get_ctx_size(clock)];
@@ -24,7 +29,9 @@ void *sysclock_collector(void *args) {
         clock.read(&clock, TAG_TIME, &time, &nbytes);
 
         // Infinitely send the time
-        sensor_write_data(stdout, TAG_TIME, &time);
+        char time_str[30];
+        sprintf(time_str, "Time: %u\n", time);
+        mq_send(sensor_q, time_str, sizeof(time_str), 0);
         usleep(10000); // Little sleep to not flood output
     }
 

--- a/src/collectors/sysclock_clctr.c
+++ b/src/collectors/sysclock_clctr.c
@@ -8,6 +8,10 @@ void *sysclock_collector(void *args) {
 
     /* Open message queue to send data. */
     mqd_t sensor_q = mq_open(SENSOR_QUEUE, O_WRONLY);
+    if (sensor_q == -1) {
+        fprintf(stderr, "Sysclock collector could not open message queue '%s': '%s' \n", SENSOR_QUEUE, strerror(errno));
+        return (void *)((uint64_t)errno);
+    }
 
     /* Create system clock instance. */
     Sensor clock;

--- a/src/collectors/sysclock_clctr.c
+++ b/src/collectors/sysclock_clctr.c
@@ -28,7 +28,6 @@ void *sysclock_collector(void *args) {
 
     // Data storage
     uint8_t data[sensor_max_dsize(&clock) + 1];
-    printf("Size: %lu\n", sizeof(data));
     size_t nbytes;
 
     // Infinitely check the time
@@ -39,7 +38,7 @@ void *sysclock_collector(void *args) {
 
         // Infinitely send the time
         if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
-            fprintf(stderr, "Sysclock failed to write message to sensor queue.\n");
+            fprintf(stderr, "Sysclock couldn't send message: %s.\n", strerror(errno));
         }
         usleep(10000); // Little sleep to not flood output
     }


### PR DESCRIPTION
This PR implements an internal message queue between sensor collector threads and the main fetcher thread for sending collected data. I have enabled POSIX message queues in our QNX images now.

The current encoding being used is an array of bytes, where the first byte is a `SensorTag` to instruct how to cast the following bytes into the correct data type (`float`, `long`, etc.)