### PR TITLE
MS5611 interface is now sensor specific

### DIFF
--- a/src/collectors/sht41_clctr.c
+++ b/src/collectors/sht41_clctr.c
@@ -5,7 +5,7 @@
 #include "collectors.h"
 #include "sensor_api.h"
 
-/** 
+/**
  * Collector thread for the SHT41 sensor.
  * @param args Arguments in the form of `collector_args_t`
  * @return The error `errno_t` which caused the thread to exit, encoded as a pointer.

--- a/src/collectors/sysclock_clctr.c
+++ b/src/collectors/sysclock_clctr.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <time.h>
 
-/** 
+/**
  * Collector thread for the system clock.
  * @param args Arguments in the form of `collector_args_t`
  * @return The error `errno_t` which caused the thread to exit, encoded as a pointer.

--- a/src/drivers/ms5611/ms5611.c
+++ b/src/drivers/ms5611/ms5611.c
@@ -5,8 +5,8 @@
  * Sensor API interface implementation for the MS5611 pressure and temperature sensor which uses I2C communication.
  *
  * See
- * https://www.te.com/commerce/DocumentDelivery/DDEController?Action=showdoc&DocId=Data+Sheet%7FMS5611-01BA03%7FB3%7Fpdf%7FEnglish%7FENG_DS_MS5611-01BA03_B3.pdf%7FCAT-BLPS0036
- * for the MS5611 data sheet.
+ * https://www.te.com/commerce/DocumentDelivery/DDEController?Action=showdoc&DocId=Data+Sheet%7FMS5611-01BA03%7FB3%7Fpdf%7FEnglish%7FENG_DS_MS5611-01BA03_B3.pdf%7FCAT-BLPS0036.
+ * for the MS5611 data sheet:
  *
  * See
  * https://www.amsys-sensor.com/downloads/notes/ms5611-precise-altitude-measurement-with-a-pressure-sensor-module-amsys-509e.pdf
@@ -17,13 +17,9 @@
 #include <errno.h>
 #include <hw/i2c.h>
 #include <math.h>
-#include <stdbool.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-
-/** Number of calibration coefficients */
-#define NUM_COEFFICIENTS 8
 
 /** Macro to early return an error. */
 #define return_err(err)                                                                                                \
@@ -41,19 +37,8 @@
 /** Defines constant for the absolute temperature in Kelvins. */
 #define T 273
 
-typedef struct {
-    uint16_t coefs[NUM_COEFFICIENTS]; /**< The calibration coefficients of the sensor. */
-    float ground_pressure;            /**< The pressure at the ground level; set when the sensor is started. */
-} MS5611Context;
-
-/** A list of data types that can be read by the MS5611 */
-static const SensorTag TAGS[] = {TAG_TEMPERATURE, TAG_PRESSURE, TAG_ALTITUDE};
-
-/** Access sensor tag data from sensor API. */
-extern const SensorTagData SENSOR_TAG_DATA[];
-
 /** All of the I2C commands that can be used on the MS5611 sensor. */
-typedef enum ms5611_cmd_t {
+typedef enum {
     CMD_RESET = 0x1E,    /**< ADC reset command */
     CMD_PROM_RD = 0xA0,  /**< Prom read command */
     CMD_ADC_CONV = 0x40, /**< ADC conversion command */
@@ -61,33 +46,17 @@ typedef enum ms5611_cmd_t {
 } MS5611Cmd;
 
 /** The D registers on the MS5611 sensor. */
-typedef enum ms5611_dregs_t {
+typedef enum {
     D1 = 0x00, /**< D register 1 */
     D2 = 0x10, /**< D register 2 */
 } MS5611DReg;
-
-/** The resolution that is used to read the data of the MS5611 */
-typedef enum ms5611_resolution_t {
-    ADC_RES_256 = 0x00,  /**< ADC OSR=256 */
-    ADC_RES_512 = 0x02,  /**< ADC OSR=512 */
-    ADC_RES_1024 = 0x04, /**< ADC OSR=1024 */
-    ADC_RES_2048 = 0x06, /**< ADC OSR=2048 */
-    ADC_RES_4096 = 0x08, /**< ADC OSR=4096 */
-} MS5611Resolution;
-
-/** Implementation of precision in sensor API for read resolution. */
-static const MS5611Resolution PRECISIONS[] = {
-    [PRECISION_LOW] = ADC_RES_256,
-    [PRECISION_MED] = ADC_RES_1024,
-    [PRECISION_HIGH] = ADC_RES_4096,
-};
 
 /**
  * Resets the MS5611 sensor, ensuring that calibration data is loaded into the PROM.
  * @param loc The sensor's location on the I2C bus.
  * @return Any error from the attempted reset. EOK if successful.
  */
-static errno_t ms5611_reset(SensorLocation *loc) {
+errno_t ms5611_reset(SensorLocation *loc) {
     i2c_send_t reset = {.stop = 1, .len = 1, .slave = loc->addr};
     uint8_t reset_cmd[sizeof(i2c_send_t) + 1];
     memcpy(reset_cmd, &reset, sizeof(reset));
@@ -129,6 +98,7 @@ static errno_t ms5611_read_dreg(SensorLocation *loc, uint8_t dreg, uint32_t *val
     }
 
     // Wait for appropriate conversion time
+    devctl(loc->bus, DCMD_I2C_UNLOCK, NULL, 0, NULL);
     switch (dreg & 0xF) {
     case ADC_RES_256:
         usleep(900);
@@ -146,6 +116,10 @@ static errno_t ms5611_read_dreg(SensorLocation *loc, uint8_t dreg, uint32_t *val
         usleep(10000);
         break;
     }
+
+    // Re-lock bus after waiting
+    err = devctl(loc->bus, DCMD_I2C_LOCK, NULL, 0, NULL);
+    if (err != EOK) return err;
 
     // Read D register
     i2c_sendrecv_t read = {.slave = loc->addr, .stop = 1, .send_len = 1, .recv_len = 3};
@@ -171,138 +145,117 @@ static errno_t ms5611_read_dreg(SensorLocation *loc, uint8_t dreg, uint32_t *val
 }
 
 /**
- * Prepares the MS5611 for reading and initializes the sensor context with the calibration coefficients.
- * @param sensor A reference to an MS5611 sensor.
- * @return The error status of the call. EOK if successful.
+ * Compute the double precision calculation.
+ * @param dt The temperature delta.
+ * @param off A pointer to the offset value.
+ * @param sens A pointer to the sensitivity value.
+ * @param temp A pointer to the current temperature value in millidegrees Celsius.
  */
-static errno_t ms5611_open(Sensor *sensor) {
+static void double_precision(double dt, double *off, double *sens, double *temp) {
+    double t2 = 0;
+    double off2 = 0;
+    double sens2 = 0;
 
-    // Load calibration into PROM
-    errno_t err = ms5611_reset(&sensor->loc);
-    if (err != EOK) return err;
-    usleep(10000); // Takes some time to reset
+    if (*temp < 20) {
+        t2 = (dt * dt) / pow(2, 31);
+        double temp_square = pow((*temp - 2000), 2);
+        off2 = (5 * temp_square) / 2;
+        sens2 = (5 * temp_square) / 4;
 
-    // PROM read command buffer
-    i2c_sendrecv_t prom_read = {.stop = 1, .slave = sensor->loc.addr, .send_len = 1, .recv_len = 2};
-    uint8_t prom_read_cmd[sizeof(prom_read) + sizeof(uint16_t)] = {0};
-    memcpy(prom_read_cmd, &prom_read, sizeof(prom_read));
-
-    // Read calibration data into sensor context
-    MS5611Context *ms5611_context = (MS5611Context *)sensor->context.data;
-    err = devctl(sensor->loc.bus, DCMD_I2C_LOCK, NULL, 0, NULL); // Lock I2C bus
-    if (err != EOK) return err;
-
-    for (uint8_t i = 0; i < NUM_COEFFICIENTS; i++) {
-
-        // Read from PROM
-        prom_read_cmd[sizeof(prom_read)] = CMD_PROM_RD + sizeof(uint16_t) * i; // Command to read next coefficient
-        err = devctl(sensor->loc.bus, DCMD_I2C_SENDRECV, &prom_read_cmd, sizeof(prom_read_cmd), NULL);
-        if (err != EOK) break;
-
-        // Store calibration coefficient
-        memcpy_be(&ms5611_context->coefs[i], &prom_read_cmd[sizeof(prom_read)], sizeof(uint16_t));
+        if (*temp < -15) {
+            temp_square = pow((*temp + 1500), 2);
+            off2 = off2 + 7 * temp_square;
+            sens2 = sens2 + 11 * temp_square / 2;
+        }
     }
 
-    err = devctl(sensor->loc.bus, DCMD_I2C_UNLOCK, NULL, 0, NULL); // Unlock I2C bus
-    if (err != EOK) return err;
-
-    // Get the ground pressure
-    size_t nbytes;
-    err = sensor->read(sensor, TAG_PRESSURE, &ms5611_context->ground_pressure, &nbytes);
-    return err;
+    *temp -= t2;
+    *off -= off2;
+    *sens -= sens2;
 }
 
 /**
  * Reads the specified data from the MS5611.
- * @param sensor A reference to an MS5611 sensor.
- * @param tag The tag of the data type that should be read.
- * @param buf A pointer to the memory location to store the data.
- * @param nbytes The number of bytes that were written into the byte array buffer.
- * @return Error status of reading from the sensor. EOK if successful.
+ * @param loc The location of the MS5611 sensor on the I2C bus.
+ * @param res The resolution to read the MS5611 at.
+ * @param ctx The context containing calibration coefficients and ground pressure.
+ * @param precise True to use second order calculation for higher precision, false for quicker calculation.
+ * @param temperature Storage location of the temperature value in degrees Celsius. NULL to skip calculation.
+ * @param pressure Storage location of the pressure value in kPa. NULL to skip calculation.
+ * @param altitude Storage location of the altitude value in m. NULL to skip calculation.
+ * @return EOK if no error, otherwise the type of error that occurred.
  */
-static errno_t ms5611_read(Sensor *sensor, const SensorTag tag, void *buf, size_t *nbytes) {
+errno_t ms5611_read_all(SensorLocation *loc, MS5611Resolution res, MS5611Context *ctx, bool precise,
+                        double *temperature, double *pressure, double *altitude) {
 
-    // Read D registers with configured precision
+    // Variables for calculation
+    double temp;
+    double pres;
+
+    // Read D registers with configured resolution
     uint32_t d1, d2;
-    errno_t err = ms5611_read_dreg(&sensor->loc, D1 + PRECISIONS[sensor->precision], &d1);
+    errno_t err = ms5611_read_dreg(loc, D1 + res, &d1);
     if (err != EOK) return err;
-    err = ms5611_read_dreg(&sensor->loc, D2 + PRECISIONS[sensor->precision], &d2);
+    err = ms5611_read_dreg(loc, D2 + res, &d2);
     if (err != EOK) return err;
 
     // Extract context
-    MS5611Context *ctx = (MS5611Context *)sensor->context.data;
-
     // Calculate 1st order pressure and temperature (MS5607 1st order algorithm)
     double dt = d2 - ctx->coefs[5] * pow(2, 8);
     double off = ctx->coefs[2] * pow(2, 16) + dt * ctx->coefs[4] / pow(2, 7);
     double sens = ctx->coefs[1] * pow(2, 15) + dt * ctx->coefs[3] / pow(2, 8);
 
-    double temperature = (2000 + ((dt * ctx->coefs[6]) / pow(2, 23)));
+    temp = (2000 + ((dt * ctx->coefs[6]) / pow(2, 23)));
 
-    // Second order algorithm (only if high precision was chosen)
-    if (sensor->precision == PRECISION_HIGH) {
-        double t2 = 0;
-        double off2 = 0;
-        double sens2 = 0;
+    // Second order algorithm only if high precision was chosen
+    if (precise) double_precision(dt, &off, &sens, &temp);
 
-        if (temperature < 20) {
-            t2 = (dt * dt) / pow(2, 31);
-            double temp_square = pow((temperature - 2000), 2);
-            off2 = (5 * temp_square) / 2;
-            sens2 = (5 * temp_square) / 4;
-
-            if (temperature < -15) {
-                temp_square = pow((temperature + 1500), 2);
-                off2 = off2 + 7 * temp_square;
-                sens2 = sens2 + 11 * temp_square / 2;
-            }
-        }
-
-        temperature -= t2;
-        off -= off2;
-        sens -= sens2;
+    // Store temperature if requested
+    if (temperature != NULL) {
+        *temperature = temp / 100; // Convert from millidegrees Celsius to degrees Celsius
     }
 
-    switch (tag) {
-    case TAG_TEMPERATURE: {
-        float f_temp = temperature / 100; // Degrees C
-        memcpy(buf, &f_temp, sizeof(f_temp));
-        *nbytes = sizeof(f_temp);
-    } break;
-    case TAG_PRESSURE: {
-        float pressure = (((d1 * sens) / (pow(2, 21)) - off) / pow(2, 15)) / 1000; // kPa
-        memcpy(buf, &pressure, sizeof(pressure));
-        *nbytes = sizeof(pressure);
-        break;
-    }
-    case TAG_ALTITUDE: {
-        double pressure = ((((d1 * sens) / (pow(2, 21)) - off) / pow(2, 15)) / 1000); // kPa
-
-        // This calculation assumes initial altitude is 0
-        float altitude = -((R * T) / (g * M)) * log(pressure / (double)ctx->ground_pressure);
-        memcpy(buf, &altitude, sizeof(altitude));
-        *nbytes = sizeof(altitude);
-        break;
-    }
-    default:
-        return EINVAL;
+    // Calculate pressure unless it's not needed for any calculation
+    if (pressure != NULL || altitude != NULL) {
+        pres = (((d1 * sens) / (pow(2, 21)) - off) / pow(2, 15)) / 1000; // kPa
+        *pressure = pres;
     }
 
-    return EOK;
+    // This calculation assumes initial altitude is 0
+    if (altitude != NULL) {
+        *altitude = -((R * T) / (g * M)) * log(pres / ctx->ground_pressure);
+    }
+
+    return err;
 }
 
 /**
- * Initializes a sensor struct with the interface to interact with the MS5611.
- * @param sensor The sensor interface to be initialized.
- * @param bus The file descriptor of the I2C bus.
- * @param addr The address of the sensor on the I2C bus.
- * @param precision The precision to read measurements with.
+ * Initialize the coefficients of the MS5611.
+ * @param loc The location of the MS5611 sensor.
+ * @param ctx The context struct to store the coefficients in.
+ * @return EOK if no error, otherwise the type of error that occurred.
  */
-void ms5611_init(Sensor *sensor, const int bus, const uint8_t addr, const SensorPrecision precision) {
-    sensor->precision = precision;
-    sensor->loc = (SensorLocation){.bus = bus, .addr = {.addr = (addr & 0x7F), .fmt = I2C_ADDRFMT_7BIT}};
-    sensor->tag_list = (SensorTagList){.tags = TAGS, .len = sizeof(TAGS) / sizeof(SensorTag)};
-    sensor->context.size = sizeof(MS5611Context); // Size of all calibration data
-    sensor->open = &ms5611_open;
-    sensor->read = &ms5611_read;
-}
+errno_t ms5611_init_coefs(SensorLocation *loc, MS5611Context *ctx) {
+    // PROM read command buffer
+    i2c_sendrecv_t prom_read = {.stop = 1, .slave = loc->addr, .send_len = 1, .recv_len = 2};
+    uint8_t prom_read_cmd[sizeof(prom_read) + sizeof(uint16_t)] = {0};
+    memcpy(prom_read_cmd, &prom_read, sizeof(prom_read));
+
+    // Read calibration data into sensor context
+    errno_t err = devctl(loc->bus, DCMD_I2C_LOCK, NULL, 0, NULL); // Lock I2C bus
+    if (err != EOK) return err;
+
+    for (uint8_t i = 0; i < MS5611_COEFFICIENT_COUNT; i++) {
+
+        // Read from PROM
+        prom_read_cmd[sizeof(prom_read)] = CMD_PROM_RD + sizeof(uint16_t) * i; // Command to read next coefficient
+        err = devctl(loc->bus, DCMD_I2C_SENDRECV, &prom_read_cmd, sizeof(prom_read_cmd), NULL);
+        if (err != EOK) break;
+
+        // Store calibration coefficient
+        memcpy_be(&ctx->coefs[i], &prom_read_cmd[sizeof(prom_read)], sizeof(uint16_t));
+    }
+
+    err = devctl(loc->bus, DCMD_I2C_UNLOCK, NULL, 0, NULL); // Unlock I2C bus
+    return err;
+};

--- a/src/drivers/ms5611/ms5611.h
+++ b/src/drivers/ms5611/ms5611.h
@@ -10,8 +10,29 @@
 #define _MS5611_H_
 
 #include "../sensor_api.h"
+#include <stdbool.h>
 #include <stdint.h>
 
-void ms5611_init(Sensor *sensor, const int bus, const uint8_t addr, const SensorPrecision precision);
+#define MS5611_COEFFICIENT_COUNT 8
+
+/** The resolution that is used to read the data of the MS5611 */
+typedef enum ms5611_resolution_t {
+    ADC_RES_256 = 0x00,  /**< ADC OSR=256 */
+    ADC_RES_512 = 0x02,  /**< ADC OSR=512 */
+    ADC_RES_1024 = 0x04, /**< ADC OSR=1024 */
+    ADC_RES_2048 = 0x06, /**< ADC OSR=2048 */
+    ADC_RES_4096 = 0x08, /**< ADC OSR=4096 */
+} MS5611Resolution;
+
+/** Contains information needed for the MS5611 between calls. */
+typedef struct {
+    uint16_t coefs[MS5611_COEFFICIENT_COUNT]; /**< The calibration coefficients of the sensor. */
+    double ground_pressure;                   /**< The pressure at the ground level; set when the sensor is started. */
+} MS5611Context;
+
+errno_t ms5611_reset(SensorLocation *loc);
+errno_t ms5611_read_all(SensorLocation *loc, MS5611Resolution res, MS5611Context *ctx, bool precise, double *temp,
+                        double *pressure, double *altitude);
+errno_t ms5611_init_coefs(SensorLocation *loc, MS5611Context *ctx);
 
 #endif // _MS5611_H_


### PR DESCRIPTION
The MS5611 sensor interface is now specific to the sensor itself. Batch reads are possible and more control over the sensor sensitivity.

The MS5611 no longer implements the original sensor API interface, which is a step closer to deprecating it.