### PR TITLE
SHT41 driver overhaul

### DIFF
--- a/src/collectors/sht41_clctr.c
+++ b/src/collectors/sht41_clctr.c
@@ -35,7 +35,8 @@ void *sht41_collector(void *args) {
     };
 
     // Reset SHT41
-    errno_t err = sht41_reset(&loc);
+    int err = sht41_reset(&loc);
+    usleep(100); // Wait just a little bit
     if (err != EOK) {
         fprintf(stderr, "%s\n", strerror(err));
         return_errno(err);

--- a/src/drivers/sht41/sht41.c
+++ b/src/drivers/sht41/sht41.c
@@ -36,7 +36,13 @@ typedef enum {
     CMD_READ_LOW_PREC = 0xE0,  /**< Low precision read temp & humidity command. */
     CMD_READ_MED_PREC = 0xF6,  /**< Med precision read temp & humidity command. */
     CMD_READ_HIGH_PREC = 0xFD, /**< High precision read temp & humidity command. */
-} SHT41Cmd;
+    CMD_HEATER_200_1 = 0x39,   /**< Activate heater with 200mW for 1s. */
+    CMD_HEATER_200_P1 = 0x32,  /**< Activate heater with 200mW for 0.1s. */
+    CMD_HEATER_110_1 = 0x2F,   /**< Activate heater with 110mW for 1s. */
+    CMD_HEATER_110_P1 = 0x24,  /**< Activate heater with 110mW for 0.1s. */
+    CMD_HEATER_20_1 = 0x1E,    /**< Activate heater with 20mW for 1s. */
+    CMD_HEATER_20_P1 = 0x15,   /**< Activate heater with 20mW for 0.1s. */
+} sht41_cmd_e;
 
 /** Measurement times for the various precisions, in microseconds */
 static const uint16_t MEASUREMENT_TIMES[] = {
@@ -107,7 +113,7 @@ static inline errno_t check_crc(uint8_t *buf, size_t nbytes) {
  * @param humidity A pointer to store the relative humidity in percentage.
  * @return Error status of reading from the sensor. EOK if successful.
  */
-errno_t sht41_read(SensorLocation *loc, SHT41Precision precision, float *temperature, float *humidity) {
+errno_t sht41_read(SensorLocation const *loc, sht41_prec_e precision, float *temperature, float *humidity) {
 
     i2c_send_t send = {.slave = loc->addr, .stop = 1, .len = 1};
     uint8_t send_cmd[sizeof(send) + 1];
@@ -165,7 +171,7 @@ errno_t sht41_read(SensorLocation *loc, SHT41Precision precision, float *tempera
  * @param loc The sensor's location on the I2C bus.
  * @return Any error from the attempted reset. EOK if successful.
  */
-errno_t sht41_reset(SensorLocation *loc) {
+errno_t sht41_reset(SensorLocation const *loc) {
     i2c_send_t reset = {.stop = 1, .len = 1, .slave = loc->addr};
     uint8_t reset_cmd[sizeof(reset) + 1];
     memcpy(reset_cmd, &reset, sizeof(reset));
@@ -188,7 +194,7 @@ return_defer:
  * @param serial_no A pointer to the location to store the serial number.
  * @return EOK if successful, otherwise the error that occurred.
  */
-errno_t sht41_serial_no(SensorLocation *loc, uint32_t *serial_no) {
+errno_t sht41_serial_no(SensorLocation const *loc, uint32_t *serial_no) {
 
     // Prepare read command
     i2c_send_t hdr = {.stop = 1, .len = 1, .slave = loc->addr};
@@ -225,4 +231,16 @@ errno_t sht41_serial_no(SensorLocation *loc, uint32_t *serial_no) {
 return_defer:
     devctl(loc->bus, DCMD_I2C_UNLOCK, NULL, 0, NULL); // Unlock bus
     return err;
+}
+
+/**
+ * Heats up the SHT41 sensor.
+ * WARNING: May draw a large amount of current.
+ * @param loc The location of the SHT41 sensor on the I2C bus.
+ * @param duration The duration to heat the SHT41 sensor for.
+ * @param wattage The wattage to use when heating the SHT41 sensor.
+ * @return EOK if successful, otherwise returns the error that occurred.
+ */
+errno_t sht41_heat(SensorLocation const *loc, sht41_dur_e duration, sht41_wattage_e wattage) {
+    return ENOSYS; // Not implemented yet
 }

--- a/src/drivers/sht41/sht41.c
+++ b/src/drivers/sht41/sht41.c
@@ -26,6 +26,9 @@
 /** Defines the number of bytes to be included in the CRC calculation. */
 #define SHT41_CRC_LEN 3
 
+/** The number of microseconds to wait before reading serial number after making a read request. */
+#define SERIAL_WAIT 10
+
 /** Some of the I2C commands that can be used on the SHT41 sensor. */
 typedef enum {
     CMD_SOFT_RESET = 0x94,     /**< Soft reset command. */
@@ -199,7 +202,7 @@ errno_t sht41_serial_no(SensorLocation *loc, uint32_t *serial_no) {
     // Prepare sensor for read
     err = devctl(loc->bus, DCMD_I2C_SEND, read_cmd, sizeof(read_cmd), NULL);
     if (err != EOK) goto return_defer;
-    usleep(1000);
+    usleep(SERIAL_WAIT);
 
     // Receive serial number
     i2c_recv_t rcv_hdr = {.slave = loc->addr, .len = 6, .stop = 1};

--- a/src/drivers/sht41/sht41.h
+++ b/src/drivers/sht41/sht41.h
@@ -2,6 +2,8 @@
  * @file sht41.h
  * @brief Header file containing the necessary types and function prototypes for controlling the SHT41 temperature and
  * humidity sensor
+ *
+ * Define SHT41_USE_CRC_LOOKUP to use a lookup table for the sht41's CRC. CRCs on the SHT41 disabled otherwise.
  */
 #ifndef _SHT41_H_
 #define _SHT41_H_
@@ -9,8 +11,14 @@
 #include "../sensor_api.h"
 #include <stdint.h>
 
-// Define SHT41_USE_CRC_LOOKUP to use a lookup table for the sht41's CRC. CRCs on the SHT41 disabled otherwise
+/** The precision to read the SHT41 sensor with. */
+typedef enum {
+    SHT41_LOW_PRES,  /**< Low precision. */
+    SHT41_MED_PRES,  /**< Medium precision. */
+    SHT41_HIGH_PRES, /**< High precision. */
+} SHT41Precision;
 
-void sht41_init(Sensor *sensor, const int bus, const uint8_t addr, const SensorPrecision precision);
+errno_t sht41_reset(SensorLocation *loc);
+errno_t sht41_read(SensorLocation *loc, SHT41Precision precision, float *temperature, float *humidity);
 
 #endif // _SHT41_H_

--- a/src/drivers/sht41/sht41.h
+++ b/src/drivers/sht41/sht41.h
@@ -20,5 +20,6 @@ typedef enum {
 
 errno_t sht41_reset(SensorLocation *loc);
 errno_t sht41_read(SensorLocation *loc, SHT41Precision precision, float *temperature, float *humidity);
+errno_t sht41_serial_no(SensorLocation *loc, uint32_t *serial_no);
 
 #endif // _SHT41_H_

--- a/src/drivers/sht41/sht41.h
+++ b/src/drivers/sht41/sht41.h
@@ -27,13 +27,14 @@ typedef enum {
 
 /** The duration to heat the SHT41 sensor for. */
 typedef enum {
-    SHT41_HEAT_1s,  /**< 1 second. */
-    SHT41_HEAT_P1s, /**< 0.1 seconds. */
+    SHT41_HEAT_1S,  /**< 1 second. */
+    SHT41_HEAT_P1S, /**< 0.1 seconds. */
 } sht41_dur_e;
 
-errno_t sht41_reset(SensorLocation const *loc);
-errno_t sht41_read(SensorLocation const *loc, sht41_prec_e precision, float *temperature, float *humidity);
-errno_t sht41_serial_no(SensorLocation const *loc, uint32_t *serial_no);
-errno_t sht41_heat(SensorLocation const *loc, sht41_dur_e duration, sht41_wattage_e wattage);
+int sht41_reset(SensorLocation const *loc);
+int sht41_read(SensorLocation const *loc, sht41_prec_e precision, float *temperature, float *humidity);
+int sht41_serial_no(SensorLocation const *loc, uint32_t *serial_no);
+int sht41_heat(SensorLocation const *loc, sht41_dur_e duration, sht41_wattage_e wattage, float *temperature,
+               float *humidity);
 
 #endif // _SHT41_H_

--- a/src/drivers/sht41/sht41.h
+++ b/src/drivers/sht41/sht41.h
@@ -16,10 +16,24 @@ typedef enum {
     SHT41_LOW_PRES,  /**< Low precision. */
     SHT41_MED_PRES,  /**< Medium precision. */
     SHT41_HIGH_PRES, /**< High precision. */
-} SHT41Precision;
+} sht41_prec_e;
 
-errno_t sht41_reset(SensorLocation *loc);
-errno_t sht41_read(SensorLocation *loc, SHT41Precision precision, float *temperature, float *humidity);
-errno_t sht41_serial_no(SensorLocation *loc, uint32_t *serial_no);
+/** The wattage to use for heating the SHT41 sensor. */
+typedef enum {
+    SHT41_WATT_200, /**< 200mW. */
+    SHT41_WATT_110, /**< 110mW. */
+    SHT41_WATT_20,  /**< 20mW. */
+} sht41_wattage_e;
+
+/** The duration to heat the SHT41 sensor for. */
+typedef enum {
+    SHT41_HEAT_1s,  /**< 1 second. */
+    SHT41_HEAT_P1s, /**< 0.1 seconds. */
+} sht41_dur_e;
+
+errno_t sht41_reset(SensorLocation const *loc);
+errno_t sht41_read(SensorLocation const *loc, sht41_prec_e precision, float *temperature, float *humidity);
+errno_t sht41_serial_no(SensorLocation const *loc, uint32_t *serial_no);
+errno_t sht41_heat(SensorLocation const *loc, sht41_dur_e duration, sht41_wattage_e wattage);
 
 #endif // _SHT41_H_


### PR DESCRIPTION
SHT41 driver is now independent of any sensor interface (despite `SensorLocation` which will be removed later).

This PR also implements two new functions for the driver to cover the remaining I2C commands: `sht41_serial_no()` and `sht41_heat()`.

Finally, some function signatures had `errno_t` changed to `int` as per #34.