### PR TITLE
Relative types

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,41 @@ Pressure: 99.94 kPa
 ...
 ```
 
-All sensor data output is printed in plain-text, with its type specifier (i.e. temperature), its value and its unit.
+Sensor data output can either be printed in plain-text, or it can be read from the named message queue
+`fetcher/sensors`.
+
+Messages on the message queue start with a one-byte type specifier which is one of the following:
+
+```c
+/** Describes possible data types that fetcher is capable of producing. */
+typedef enum {
+    TAG_TEMPERATURE = 0,      /**< Temperature in degrees Celsius */
+    TAG_PRESSURE = 1,         /**< Pressure in kilo Pascals */
+    TAG_HUMIDITY = 2,         /**< Humidity in % relative humidity */
+    TAG_TIME = 3,             /**< Time in milliseconds */
+    TAG_ALTITUDE_SEA = 4,     /**< Altitude above sea level in meters */
+    TAG_ALTITUDE_REL = 5,     /**< Altitude above launch height in meters */
+    TAG_ANGULAR_VEL = 6,      /**< Angular velocity in degrees per second */
+    TAG_LINEAR_ACCEL_REL = 7, /**< Relative linear acceleration in meters per second squared */
+    TAG_LINEAR_ACCEL_ABS = 8, /**< Absolute linear acceleration in meters per second squared */
+} SensorTag;
+```
+
+Followed by data representing the measurement.
+
+Temperature, pressure, humidity and altitude are floats.
+Time is a 32 bit integer.
+Linear acceleration and angular velocity are 3D vectors (`vec3d_t`) of 3 floats.
 
 ## Board ID EEPROM Encoding
 
 In order for fetcher to recognize the sensors on the board, the EEPROM must encode the ID in this format:
 
 ```
-CU InSpace <board name> REV <x>: <manufacture date>
+CU InSpace <board name>
+REV <x>: <manufacture date>
 <sensor 1 id> <address>
-<sensor 2 id> <address>
+<sensor 2 id> <address> <address2>
 ```
 
 **Fields:**
@@ -33,6 +58,7 @@ CU InSpace <board name> REV <x>: <manufacture date>
 - `REV <x>`: The revision of the board. Ex: `REV B`
 - `<sensor id>`: The identifier of the sensor. Ex: `MS5611`
 - `<address>`: The 7 bit I2C address of the sensor in hexadecimal (without the leading 0x). Ex: `77`
+  - It is possible to have more than one address per sensor type for boards with duplicates
 
 <!--- Links --->
 

--- a/fetcher.use
+++ b/fetcher.use
@@ -10,8 +10,9 @@ DESCRIPTION:
     over stdout.
 
 SYNTAX:
-    fetcher [-o file]
+    fetcher
 
 OPTIONS:
-    -o file      Provides an output file for fetcher to write sensor data. If
-                 none provided, the stdout is used.
+    -p           If this flag is passed, fetcher will print its sensor data to
+                 stdout. Enabling this flag will take messages off the output
+                 message queue.

--- a/src/collectors/lsm6dso32_clctr.c
+++ b/src/collectors/lsm6dso32_clctr.c
@@ -43,8 +43,8 @@ void *lsm6dso32_collector(void *args) {
         }
 
         // Read linear acceleration
-        sensor_read(lsm6dso32, TAG_LINEAR_ACCEL, &data[1], &nbytes);
-        data[0] = TAG_LINEAR_ACCEL;
+        sensor_read(lsm6dso32, TAG_LINEAR_ACCEL_REL, &data[1], &nbytes);
+        data[0] = TAG_LINEAR_ACCEL_REL;
         if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
             fprintf(stderr, "LSM6DSO32 couldn't send message: %s\n", strerror(errno));
         }

--- a/src/collectors/ms5611_clctr.c
+++ b/src/collectors/ms5611_clctr.c
@@ -87,7 +87,7 @@ void *ms5611_collector(void *args) {
         }
 
         // Transmit altitude
-        measurement.type = TAG_ALTITUDE;
+        measurement.type = TAG_ALTITUDE_REL;
         measurement.data = (float)altitude;
         if (mq_send(sensor_q, (char *)&measurement, sizeof(measurement), 0) == -1) {
             fprintf(stderr, "MS5611 couldn't send message: %s.\n", strerror(errno));

--- a/src/drivers/lsm6dso32/lsm6dso32.c
+++ b/src/drivers/lsm6dso32/lsm6dso32.c
@@ -83,7 +83,7 @@ enum imu_reg {
     if (err != EOK) return err
 
 /** A list of data types that can be read by the LSM6DSO32. */
-static const SensorTag TAGS[] = {TAG_TEMPERATURE, TAG_LINEAR_ACCEL, TAG_ANGULAR_VEL};
+static const SensorTag TAGS[] = {TAG_TEMPERATURE, TAG_LINEAR_ACCEL_REL, TAG_ANGULAR_VEL};
 
 /**
  * Write data to a register of the LSM6DSO32.
@@ -156,7 +156,7 @@ static errno_t lsm6dso32_read(Sensor *sensor, const SensorTag tag, void *buf, si
         *nbytes = sizeof(float);
         break;
     }
-    case TAG_LINEAR_ACCEL: {
+    case TAG_LINEAR_ACCEL_REL: {
 
         int16_t x;
         err = lsm6dso32_read_byte(sensor, OUTX_L_A, (uint8_t *)(&x)); // Read low byte

--- a/src/drivers/sensor_api.c
+++ b/src/drivers/sensor_api.c
@@ -20,12 +20,20 @@ const SensorTagData SENSOR_TAG_DATA[] = {
     [TAG_HUMIDITY] =
         {.name = "Humidity", .unit = "%RH", .fmt_str = "%.2f", .dsize = sizeof(float), .dtype = TYPE_FLOAT},
     [TAG_TIME] = {.name = "Time", .unit = "ms", .fmt_str = "%u", .dsize = sizeof(uint32_t), .dtype = TYPE_U32},
-    [TAG_ALTITUDE] = {.name = "Altitude", .unit = "m", .fmt_str = "%.2f", .dsize = sizeof(float), .dtype = TYPE_FLOAT},
-    [TAG_LINEAR_ACCEL] = {.name = "Linear acceleration",
-                          .unit = "m/s^2",
-                          .fmt_str = "%.2fX, %.2fY, %.2fZ",
-                          .dsize = sizeof(vec3d_t),
-                          .dtype = TYPE_VEC3D},
+    [TAG_ALTITUDE_REL] =
+        {.name = "Altitude rel", .unit = "m", .fmt_str = "%.2f", .dsize = sizeof(float), .dtype = TYPE_FLOAT},
+    [TAG_ALTITUDE_SEA] =
+        {.name = "Altitude sea level", .unit = "m", .fmt_str = "%.2f", .dsize = sizeof(float), .dtype = TYPE_FLOAT},
+    [TAG_LINEAR_ACCEL_ABS] = {.name = "Absolute linear acceleration",
+                              .unit = "m/s^2",
+                              .fmt_str = "%.2fX, %.2fY, %.2fZ",
+                              .dsize = sizeof(vec3d_t),
+                              .dtype = TYPE_VEC3D},
+    [TAG_LINEAR_ACCEL_REL] = {.name = "Relative linear acceleration",
+                              .unit = "m/s^2",
+                              .fmt_str = "%.2fX, %.2fY, %.2fZ",
+                              .dsize = sizeof(vec3d_t),
+                              .dtype = TYPE_VEC3D},
     [TAG_ANGULAR_VEL] = {.name = "Angular velocity",
                          .unit = "dps",
                          .fmt_str = "%.2fX, %.2fY, %.2fZ",
@@ -86,8 +94,8 @@ inline errno_t __attribute__((always_inline)) sensor_open(Sensor sensor) { retur
  * @param nbytes Will be populated with the number of bytes that were stored in buf after the read.
  * @return Error status of setting up the sensor. EOK if successful.
  */
-inline errno_t __attribute__((always_inline))
-sensor_read(Sensor sensor, const SensorTag tag, void *buf, size_t *nbytes) {
+inline errno_t __attribute__((always_inline)) sensor_read(Sensor sensor, const SensorTag tag, void *buf,
+                                                          size_t *nbytes) {
     return sensor.read(&sensor, tag, buf, nbytes);
 }
 

--- a/src/drivers/sensor_api.c
+++ b/src/drivers/sensor_api.c
@@ -94,8 +94,8 @@ inline errno_t __attribute__((always_inline)) sensor_open(Sensor sensor) { retur
  * @param nbytes Will be populated with the number of bytes that were stored in buf after the read.
  * @return Error status of setting up the sensor. EOK if successful.
  */
-inline errno_t __attribute__((always_inline)) sensor_read(Sensor sensor, const SensorTag tag, void *buf,
-                                                          size_t *nbytes) {
+inline errno_t __attribute__((always_inline))
+sensor_read(Sensor sensor, const SensorTag tag, void *buf, size_t *nbytes) {
     return sensor.read(&sensor, tag, buf, nbytes);
 }
 

--- a/src/drivers/sensor_api.h
+++ b/src/drivers/sensor_api.h
@@ -24,7 +24,7 @@ typedef struct {
     float z;
 } vec3d_t;
 
-/** Describes what data type the sensor is able to read. */
+/** Describes possible data types that fetcher is capable of producing. */
 typedef enum {
     TAG_TEMPERATURE = 0,      /**< Temperature in degrees Celsius */
     TAG_PRESSURE = 1,         /**< Pressure in kilo Pascals */

--- a/src/drivers/sensor_api.h
+++ b/src/drivers/sensor_api.h
@@ -26,13 +26,15 @@ typedef struct {
 
 /** Describes what data type the sensor is able to read. */
 typedef enum {
-    TAG_TEMPERATURE,  /**< Temperature in degrees Celsius */
-    TAG_PRESSURE,     /**< Pressure in kilo Pascals */
-    TAG_HUMIDITY,     /**< Humidity in % relative humidity */
-    TAG_TIME,         /**< Time in milliseconds */
-    TAG_ALTITUDE,     /**< Altitude in meters */
-    TAG_ANGULAR_VEL,  /**< Angular velocity in degrees per second */
-    TAG_LINEAR_ACCEL, /**< Linear acceleration in meters per second squared */
+    TAG_TEMPERATURE = 0,      /**< Temperature in degrees Celsius */
+    TAG_PRESSURE = 1,         /**< Pressure in kilo Pascals */
+    TAG_HUMIDITY = 2,         /**< Humidity in % relative humidity */
+    TAG_TIME = 3,             /**< Time in milliseconds */
+    TAG_ALTITUDE_SEA = 4,     /**< Altitude above sea level in meters */
+    TAG_ALTITUDE_REL = 5,     /**< Altitude above launch height in meters */
+    TAG_ANGULAR_VEL = 6,      /**< Angular velocity in degrees per second */
+    TAG_LINEAR_ACCEL_REL = 7, /**< Relative linear acceleration in meters per second squared */
+    TAG_LINEAR_ACCEL_ABS = 8, /**< Absolute linear acceleration in meters per second squared */
 } SensorTag;
 
 /** Describes the data type of the data associated with a tag. */


### PR DESCRIPTION
Fetcher now supports relative types from the packet spec. It is important to know what altitude measurements are relative to for instance (i.e. sea level, or launch height?).

In addition to this change, the README now describes the message format for sensor data on fetcher's output message queue. This allows packager to instead receive sensor data from a message queue with synchronization rather than from piped text, removing the KSH shell dependency.

Fetcher can still print output using the `-p` command line flag. Note that this reads messages off the message queue and prints them, so it is not "safe" to use the message queue from another program while fetcher is printing (unless you don't care about missing some data).