### PR TITLE
LSM6DSO32 interface change

### DIFF
--- a/src/collectors/lsm6dso32_clctr.c
+++ b/src/collectors/lsm6dso32_clctr.c
@@ -71,7 +71,6 @@ void *lsm6dso32_collector(void *args) {
             fprintf(stderr, "LSM6DSO32 could not read temperature: %s\n", strerror(errno));
         } else {
             data[0] = TAG_TEMPERATURE;
-            printf("===== %f\n", (float)temperature);
             *((float *)(data + 1)) = (float)temperature;
             if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
                 fprintf(stderr, "LSM6DSO32 couldn't send message: %s\n", strerror(errno));

--- a/src/collectors/lsm6dso32_clctr.c
+++ b/src/collectors/lsm6dso32_clctr.c
@@ -28,32 +28,39 @@ void *lsm6dso32_collector(void *args) {
     int err;
     err = lsm6dso32_reset(&loc);
     if (err != EOK) {
-        fprintf(stderr, "Failed to reset LSM6DSO32: %s\n", strerror(errno));
+        fprintf(stderr, "Failed to reset LSM6DSO32: %s\n", strerror(err));
         return_err(err);
     }
+
+    err = lsm6dso32_mem_reboot(&loc);
+    if (err != EOK) {
+        fprintf(stderr, "Failed to reboot LSM6DSO32 memory content: %s\n", strerror(err));
+        return_err(err);
+    }
+
     usleep(100);
 
     err = lsm6dso32_set_acc_fsr(&loc, LA_FS_32G);
     if (err != EOK) {
-        fprintf(stderr, "Failed to set LSM6DSO32 accelerometer FSR: %s\n", strerror(errno));
+        fprintf(stderr, "Failed to set LSM6DSO32 accelerometer FSR: %s\n", strerror(err));
         return_err(err);
     }
 
     err = lsm6dso32_set_gyro_fsr(&loc, G_FS_500);
     if (err != EOK) {
-        fprintf(stderr, "Failed to set LSM6DSO32 gyroscope FSR: %s\n", strerror(errno));
+        fprintf(stderr, "Failed to set LSM6DSO32 gyroscope FSR: %s\n", strerror(err));
         return_err(err);
     }
 
     err = lsm6dso32_set_acc_odr(&loc, LA_ODR_6664);
     if (err != EOK) {
-        fprintf(stderr, "Failed to set LSM6DSO32 accelerometer ODR: %s\n", strerror(errno));
+        fprintf(stderr, "Failed to set LSM6DSO32 accelerometer ODR: %s\n", strerror(err));
         return_err(err);
     }
 
     err = lsm6dso32_set_gyro_odr(&loc, G_ODR_6664);
     if (err != EOK) {
-        fprintf(stderr, "Failed to set LSM6DSO32 gyroscope ODR: %s\n", strerror(errno));
+        fprintf(stderr, "Failed to set LSM6DSO32 gyroscope ODR: %s\n", strerror(err));
         return_err(err);
     }
 

--- a/src/collectors/lsm6dso32_clctr.c
+++ b/src/collectors/lsm6dso32_clctr.c
@@ -40,6 +40,12 @@ void *lsm6dso32_collector(void *args) {
 
     usleep(100);
 
+    err = lsm6dso32_high_performance(&loc, true);
+    if (err != EOK) {
+        fprintf(stderr, "Failed to set LSM6DSO32 to high performance mode: %s\n", strerror(err));
+        return_err(err);
+    }
+
     err = lsm6dso32_set_acc_fsr(&loc, LA_FS_32G);
     if (err != EOK) {
         fprintf(stderr, "Failed to set LSM6DSO32 accelerometer FSR: %s\n", strerror(err));

--- a/src/collectors/lsm6dso32_clctr.c
+++ b/src/collectors/lsm6dso32_clctr.c
@@ -3,6 +3,8 @@
 #include "sensor_api.h"
 #include <stdio.h>
 
+#define return_err(err) return (void *)((uint64_t)errno)
+
 /**
  * Collector thread for the LSM6DSO32 sensor.
  * @param args Arguments in the form of `collector_args_t`
@@ -15,43 +17,61 @@ void *lsm6dso32_collector(void *args) {
     if (sensor_q == -1) {
         fprintf(stderr, "LSM6DSO32 collector could not open message queue '%s': '%s' \n", SENSOR_QUEUE,
                 strerror(errno));
-        return (void *)((uint64_t)errno);
+        return_err(err);
     }
 
-    /* Create LSM6DO32 instance */
-    Sensor lsm6dso32;
-    lsm6dso32_init(&lsm6dso32, clctr_args(args)->bus, clctr_args(args)->addr, PRECISION_HIGH);
+    SensorLocation loc = {
+        .addr = {.addr = clctr_args(args)->addr, .fmt = I2C_ADDRFMT_7BIT},
+        .bus = clctr_args(args)->bus,
+    };
 
-    uint8_t lsm6dso32_context[sensor_get_ctx_size(lsm6dso32)];
-    sensor_set_ctx(&lsm6dso32, lsm6dso32_context);
-    errno_t err = sensor_open(lsm6dso32);
+    int err;
+    err = lsm6dso32_reset(&loc);
     if (err != EOK) {
-        fprintf(stderr, "%s\n", strerror(err));
-        return (void *)((uint64_t)err);
+        fprintf(stderr, "Failed to reset LSM6DSO32: %s\n", strerror(errno));
+        return_err(err);
     }
 
-    size_t nbytes;
-    uint8_t data[sensor_max_dsize(&lsm6dso32) + 1];
+    err = lsm6dso32_set_acc_fsr(&loc, LA_FS_32G);
+    if (err != EOK) {
+        fprintf(stderr, "Failed to set LSM6DSO32 accelerometer FSR: %s\n", strerror(errno));
+        return_err(err);
+    }
+
+    err = lsm6dso32_set_gyro_fsr(&loc, G_FS_500);
+    if (err != EOK) {
+        fprintf(stderr, "Failed to set LSM6DSO32 gyroscope FSR: %s\n", strerror(errno));
+        return_err(err);
+    }
+
+    uint8_t data[sizeof(vec3d_t) + 1];
+    int16_t temperature;
+    int16_t x;
+    int16_t y;
+    int16_t z;
 
     for (;;) {
 
         // Read temperature
-        sensor_read(lsm6dso32, TAG_TEMPERATURE, &data[1], &nbytes);
+        lsm6dso32_get_temp(&loc, &temperature);
         data[0] = TAG_TEMPERATURE;
+        *((float *)(data + 1)) = (float)temperature;
         if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
             fprintf(stderr, "LSM6DSO32 couldn't send message: %s\n", strerror(errno));
         }
 
         // Read linear acceleration
-        sensor_read(lsm6dso32, TAG_LINEAR_ACCEL_REL, &data[1], &nbytes);
+        lsm6dso32_get_accel(&loc, &x, &y, &z);
         data[0] = TAG_LINEAR_ACCEL_REL;
+        *((vec3d_t *)(data + 1)) = (vec3d_t){.x = x, .y = y, .z = z};
         if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
             fprintf(stderr, "LSM6DSO32 couldn't send message: %s\n", strerror(errno));
         }
 
         // Read angular velocity
-        sensor_read(lsm6dso32, TAG_ANGULAR_VEL, &data[1], &nbytes);
+        lsm6dso32_get_angular_vel(&loc, &x, &y, &z);
         data[0] = TAG_ANGULAR_VEL;
+        *((vec3d_t *)(data + 1)) = (vec3d_t){.x = x, .y = y, .z = z};
         if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
             fprintf(stderr, "LSM6DSO32 couldn't send message: %s\n", strerror(errno));
         }

--- a/src/collectors/lsm6dso32_clctr.c
+++ b/src/collectors/lsm6dso32_clctr.c
@@ -31,6 +31,7 @@ void *lsm6dso32_collector(void *args) {
         fprintf(stderr, "Failed to reset LSM6DSO32: %s\n", strerror(errno));
         return_err(err);
     }
+    usleep(100);
 
     err = lsm6dso32_set_acc_fsr(&loc, LA_FS_32G);
     if (err != EOK) {
@@ -70,6 +71,7 @@ void *lsm6dso32_collector(void *args) {
             fprintf(stderr, "LSM6DSO32 could not read temperature: %s\n", strerror(errno));
         } else {
             data[0] = TAG_TEMPERATURE;
+            printf("===== %f\n", (float)temperature);
             *((float *)(data + 1)) = (float)temperature;
             if (mq_send(sensor_q, (char *)data, sizeof(data), 0) == -1) {
                 fprintf(stderr, "LSM6DSO32 couldn't send message: %s\n", strerror(errno));

--- a/src/drivers/lsm6dso32/lsm6dso32.c
+++ b/src/drivers/lsm6dso32/lsm6dso32.c
@@ -130,7 +130,7 @@ int lsm6dso32_get_temp(SensorLocation const *loc, int16_t *temperature) {
     return_err(err);
     err = lsm6dso32_read_byte(loc, OUT_TEMP_H, ((uint8_t *)(temperature) + 1)); // Read high byte
     return_err(err);
-    *temperature /= 256.0f + 25.0f; // In degrees Celsius
+    *temperature = (*temperature / 256.0f) + 25.0f; // In degrees Celsius
     return err;
 }
 

--- a/src/drivers/lsm6dso32/lsm6dso32.c
+++ b/src/drivers/lsm6dso32/lsm6dso32.c
@@ -14,7 +14,6 @@
 #include <hw/i2c.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
@@ -239,13 +238,13 @@ int lsm6dso32_set_acc_fsr(SensorLocation const *loc, accel_fsr_e fsr) {
         // All zeroes
         break;
     case LA_FS_8G:
-        reg_val |= (0x2 << 3);
+        reg_val |= (1 << 3);
         break;
     case LA_FS_16G:
-        reg_val |= (0x3 << 3);
+        reg_val |= ((1 << 3) | (1 << 2));
         break;
     case LA_FS_32G:
-        reg_val |= (0x1 << 3);
+        reg_val |= (1 << 2);
         break;
     default:
         return EINVAL;
@@ -263,7 +262,7 @@ int lsm6dso32_set_gyro_fsr(SensorLocation const *loc, gyro_fsr_e fsr) {
 
     uint8_t reg_val;
     int err = lsm6dso32_read_byte(loc, CTRL2_G, &reg_val); // Don't overwrite other configurations
-    reg_val &= ~((1 << 3) | (1 << 2) | (1 << 1));          // Clear FSR selection bits
+    reg_val &= ~(0x0F);                                    // Clear FSR selection bits
     return_err(err);
 
     switch (fsr) {

--- a/src/drivers/lsm6dso32/lsm6dso32.c
+++ b/src/drivers/lsm6dso32/lsm6dso32.c
@@ -12,8 +12,6 @@
 #include "sensor_api.h"
 #include <errno.h>
 #include <hw/i2c.h>
-#include <stdbool.h>
-#include <stdint.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
@@ -347,6 +345,27 @@ int lsm6dso32_set_gyro_odr(SensorLocation const *loc, gyro_odr_e odr) {
     reg_val |= (uint8_t)(odr);                             // Set ODR selection
     return_err(err);
     return lsm6dso32_write_byte(loc, CTRL2_G, reg_val);
+}
+
+/**
+ * Allows high performance operating mode to be enabled/disabled.
+ * @param loc The location of the IMU on the I2C bus.
+ * @param on True to turn on high performance, false to turn it off.
+ * @return Any error which occurred communicating with the IMU, EOK if successful.
+ */
+int lsm6dso32_high_performance(SensorLocation const *loc, bool on) {
+
+    uint8_t reg_val;
+    int err = lsm6dso32_read_byte(loc, CTRL6_C, &reg_val);
+    return_err(err);
+
+    if (on) {
+        reg_val |= 0x10;
+    } else {
+        reg_val &= ~0x10;
+    }
+
+    return lsm6dso32_write_byte(loc, CTRL6_C, reg_val);
 }
 
 /**

--- a/src/drivers/lsm6dso32/lsm6dso32.c
+++ b/src/drivers/lsm6dso32/lsm6dso32.c
@@ -129,7 +129,7 @@ static errno_t lsm6dso32_read_byte(SensorLocation const *loc, uint8_t reg, uint8
 int lsm6dso32_get_temp(SensorLocation const *loc, int16_t *temperature) {
     int err = lsm6dso32_read_byte(loc, OUT_TEMP_L, (uint8_t *)(temperature)); // Read low byte
     return_err(err);
-    err = lsm6dso32_read_byte(loc, OUT_TEMP_H, (uint8_t *)(temperature) + 1); // Read high byte
+    err = lsm6dso32_read_byte(loc, OUT_TEMP_H, ((uint8_t *)(temperature) + 1)); // Read high byte
     return_err(err);
     *temperature /= 256.0f + 25.0f; // In degrees Celsius
     return err;
@@ -334,3 +334,11 @@ int lsm6dso32_disable_gyro(SensorLocation const *loc) { return lsm6dso32_set_gyr
  * @return Any error which occurred communicating with the IMU, EOK if successful.
  */
 int lsm6dso32_disable_accel(SensorLocation const *loc) { return lsm6dso32_set_gyro_odr(loc, 0); }
+
+/**
+ * Reads the "who am I" value from the sensor. Should always be equal to 0x6C.
+ * @param loc The location of the sensor on the I2C bus.
+ * @param val The value returned by the WHOAMI command.
+ * @return Any error which occurred communicating with the IMU, EOK if successful.
+ */
+int lsm6dso32_whoami(SensorLocation const *loc, uint8_t *val) { return lsm6dso32_read_byte(loc, WHO_AM_I, val); }

--- a/src/drivers/lsm6dso32/lsm6dso32.c
+++ b/src/drivers/lsm6dso32/lsm6dso32.c
@@ -35,14 +35,6 @@
  */
 #define MILLI_UNIT_PER_LSB_TO_UNIT 2.0f / 65535.0f
 
-/** Type to store the context of the IMU. */
-typedef struct {
-    /** Acceleration full scale range. */
-    uint8_t acc_fsr;
-    /** Gyroscope full scale range. */
-    uint16_t gyro_fsr;
-} LSM6DSO32Context;
-
 /** The different registers that are present in the IMU (and used by this program). */
 enum imu_reg {
     WHO_AM_I = 0x0F,   /**< Returns the hard-coded address of the IMU on the I2C bus. */
@@ -342,34 +334,3 @@ int lsm6dso32_disable_gyro(SensorLocation const *loc) { return lsm6dso32_set_gyr
  * @return Any error which occurred communicating with the IMU, EOK if successful.
  */
 int lsm6dso32_disable_accel(SensorLocation const *loc) { return lsm6dso32_set_gyro_odr(loc, 0); }
-
-/**
- * Prepares the LSM6DSO32 for reading.
- * @param sensor A reference to an LSM6DSO32 sensor.
- * @return The error status of the call. EOK if successful.
- */
-static errno_t lsm6dso32_open(Sensor *sensor) {
-
-    // Perform software reset
-    errno_t err = lsm6dso32_write_byte(sensor, CTRL3_C, 0x01);
-    return_err(err);
-
-    // TODO: We will want to operate in continuous mode for our use case (polling)
-
-    // Set the operating mode of the accelerometer to ODR of 6.66kHz (high perf)
-    // TODO: set based on configured sensor performance
-    // Full scale range of +-32g (necessary for rocket)
-    ((LSM6DSO32Context *)(sensor->context.data))->acc_fsr = 32;
-    err = lsm6dso32_write_byte(sensor, CTRL1_XL, 0xA4);
-    return_err(err);
-
-    // Set the operating mode of the gyroscope to ODR of 6.66kHz (high perf)
-    // TODO: set based on configured sensor performance
-    // TODO: what full-scale selection? Keep 500 for now
-    ((LSM6DSO32Context *)(sensor->context.data))->gyro_fsr = 500;
-    err = lsm6dso32_write_byte(sensor, CTRL2_G, 0xA1);
-    return_err(err);
-
-    // TODO: what filter configuration will give the best measurements?
-    return err;
-}

--- a/src/drivers/lsm6dso32/lsm6dso32.c
+++ b/src/drivers/lsm6dso32/lsm6dso32.c
@@ -243,6 +243,13 @@ void lsm6dso32_convert_angular_vel(gyro_fsr_e gyro_fsr, int16_t *x, int16_t *y, 
 int lsm6dso32_reset(SensorLocation const *loc) { return lsm6dso32_write_byte(loc, CTRL3_C, 0x01); }
 
 /**
+ * Reboots the memory content of the LSM6DSO32.
+ * @param loc The location of the IMU on the I2C bus.
+ * @return Any error which occurred while rebooting the IMU, EOK if successful.
+ */
+int lsm6dso32_mem_reboot(SensorLocation const *loc) { return lsm6dso32_write_byte(loc, CTRL3_C, 0x80); }
+
+/**
  * Sets the accelerometer full scale range.
  * @param loc The location of the IMU on the I2C bus.
  * @param fsr The FSR to set.

--- a/src/drivers/lsm6dso32/lsm6dso32.h
+++ b/src/drivers/lsm6dso32/lsm6dso32.h
@@ -62,6 +62,7 @@ typedef enum {
 } gyro_odr_e;
 
 int lsm6dso32_reset(SensorLocation const *loc);
+int lsm6dso32_mem_reboot(SensorLocation const *loc);
 int lsm6dso32_disable_accel(SensorLocation const *loc);
 int lsm6dso32_disable_gyro(SensorLocation const *loc);
 

--- a/src/drivers/lsm6dso32/lsm6dso32.h
+++ b/src/drivers/lsm6dso32/lsm6dso32.h
@@ -12,6 +12,9 @@
 #include "../sensor_api.h"
 #include <stdint.h>
 
+/** The value that should be returned from the WHOAMI register. */
+#define WHOAMI_VALUE 0x6C
+
 /** Represents the possible full scale range settings for linear acceleration in Gs (gravitational acceleration). */
 typedef enum {
     LA_FS_4G = 4,   /**< Full scale range of +/- 4Gs */
@@ -70,6 +73,7 @@ int lsm6dso32_set_gyro_odr(SensorLocation const *loc, gyro_odr_e odr);
 int lsm6dso32_get_temp(SensorLocation const *loc, int16_t *temperature);
 int lsm6dso32_get_accel(SensorLocation const *loc, int16_t *x, int16_t *y, int16_t *z);
 int lsm6dso32_get_angular_vel(SensorLocation const *loc, int16_t *x, int16_t *y, int16_t *z);
+int lsm6dso32_whoami(SensorLocation const *loc, uint8_t *val);
 
 void lsm6dso32_convert_accel(accel_fsr_e acc_fsr, int16_t *x, int16_t *y, int16_t *z);
 void lsm6dso32_convert_angular_vel(gyro_fsr_e gyro_fsr, int16_t *x, int16_t *y, int16_t *z);

--- a/src/drivers/lsm6dso32/lsm6dso32.h
+++ b/src/drivers/lsm6dso32/lsm6dso32.h
@@ -10,6 +10,7 @@
 #define _LSM6DSO32_
 
 #include "../sensor_api.h"
+#include <stdbool.h>
 #include <stdint.h>
 
 /** The value that should be returned from the WHOAMI register. */
@@ -70,6 +71,7 @@ int lsm6dso32_set_acc_fsr(SensorLocation const *loc, accel_fsr_e fsr);
 int lsm6dso32_set_gyro_fsr(SensorLocation const *loc, gyro_fsr_e fsr);
 int lsm6dso32_set_acc_odr(SensorLocation const *loc, accel_odr_e odr);
 int lsm6dso32_set_gyro_odr(SensorLocation const *loc, gyro_odr_e odr);
+int lsm6dso32_high_performance(SensorLocation const *loc, bool on);
 
 int lsm6dso32_get_temp(SensorLocation const *loc, int16_t *temperature);
 int lsm6dso32_get_accel(SensorLocation const *loc, int16_t *x, int16_t *y, int16_t *z);

--- a/src/drivers/lsm6dso32/lsm6dso32.h
+++ b/src/drivers/lsm6dso32/lsm6dso32.h
@@ -12,6 +12,66 @@
 #include "../sensor_api.h"
 #include <stdint.h>
 
-void lsm6dso32_init(Sensor *sensor, const int bus, const uint8_t addr, const SensorPrecision precision);
+/** Represents the possible full scale range settings for linear acceleration in Gs (gravitational acceleration). */
+typedef enum {
+    LA_FS_4G = 4,   /**< Full scale range of +/- 4Gs */
+    LA_FS_8G = 8,   /**< Full scale range of +/- 8Gs */
+    LA_FS_16G = 16, /**< Full scale range of +/- 16Gs */
+    LA_FS_32G = 32, /**< Full scale range of +/- 32Gs */
+} accel_fsr_e;
+
+/** Represents the possible full scale range settings for the gyroscope in degrees per second. */
+typedef enum {
+    G_FS_125 = 125,   /**< Full scale range of +/-125 degrees per second. */
+    G_FS_250 = 250,   /**< Full scale range of +/-250 degrees per second. */
+    G_FS_500 = 500,   /**< Full scale range of +/-500 degrees per second. */
+    G_FS_1000 = 1000, /**< Full scale range of +/-1000 degrees per second. */
+    G_FS_2000 = 2000, /**< Full scale range of +/-2000 degrees per second. */
+} gyro_fsr_e;
+
+/** Possible output data rates for linear acceleration in Hz. */
+typedef enum {
+    LA_ODR_1_6 = 0xD0,  /** 1.6 Hz */
+    LA_ODR_12_5 = 0x10, /** 12.5 Hz */
+    LA_ODR_26 = 0x20,   /** 26 Hz */
+    LA_ODR_52 = 0x30,   /** 52 Hz */
+    LA_ODR_104 = 0x40,  /** 104 Hz */
+    LA_ODR_208 = 0x50,  /** 208 Hz */
+    LA_ODR_416 = 0x60,  /** 416 Hz */
+    LA_ODR_833 = 0x70,  /** 833 Hz */
+    LA_ODR_1666 = 0x80, /** 1666 Hz */
+    LA_ODR_3332 = 0x90, /** 3332 Hz */
+    LA_ODR_6664 = 0xA0, /** 6644 Hz */
+} accel_odr_e;
+
+/** Possible output data rates for the gyroscope in Hz. */
+typedef enum {
+    G_ODR_12_5, /** 12.5 Hz */
+    G_ODR_26,   /** 26 Hz */
+    G_ODR_52,   /** 52 Hz */
+    G_ODR_104,  /** 104 Hz */
+    G_ODR_208,  /** 208 Hz */
+    G_ODR_416,  /** 416 Hz */
+    G_ODR_833,  /** 833 Hz */
+    G_ODR_1666, /** 1666 Hz */
+    G_ODR_3332, /** 3332 Hz */
+    G_ODR_6664, /** 6644 Hz */
+} gyro_odr_e;
+
+int lsm6dso32_reset(SensorLocation const *loc);
+int lsm6dso32_disable_accel(SensorLocation const *loc);
+int lsm6dso32_disable_gyro(SensorLocation const *loc);
+
+int lsm6dso32_set_acc_fsr(SensorLocation const *loc, accel_fsr_e fsr);
+int lsm6dso32_set_gyro_fsr(SensorLocation const *loc, gyro_fsr_e fsr);
+int lsm6dso32_set_acc_odr(SensorLocation const *loc, accel_odr_e odr);
+int lsm6dso32_set_gyro_odr(SensorLocation const *loc, gyro_odr_e odr);
+
+int lsm6dso32_get_temp(SensorLocation const *loc, int16_t *temperature);
+int lsm6dso32_get_accel(SensorLocation const *loc, int16_t *x, int16_t *y, int16_t *z);
+int lsm6dso32_get_angular_vel(SensorLocation const *loc, int16_t *x, int16_t *y, int16_t *z);
+
+void lsm6dso32_convert_accel(accel_fsr_e acc_fsr, int16_t *x, int16_t *y, int16_t *z);
+void lsm6dso32_convert_angular_vel(gyro_fsr_e gyro_fsr, int16_t *x, int16_t *y, int16_t *z);
 
 #endif // _LSM6DSO32_

--- a/src/drivers/lsm6dso32/lsm6dso32.h
+++ b/src/drivers/lsm6dso32/lsm6dso32.h
@@ -34,7 +34,7 @@ typedef enum {
 
 /** Possible output data rates for linear acceleration in Hz. */
 typedef enum {
-    LA_ODR_1_6 = 0xD0,  /** 1.6 Hz */
+    LA_ODR_1_6 = 0xB0,  /** 1.6 Hz */
     LA_ODR_12_5 = 0x10, /** 12.5 Hz */
     LA_ODR_26 = 0x20,   /** 26 Hz */
     LA_ODR_52 = 0x30,   /** 52 Hz */
@@ -49,16 +49,16 @@ typedef enum {
 
 /** Possible output data rates for the gyroscope in Hz. */
 typedef enum {
-    G_ODR_12_5, /** 12.5 Hz */
-    G_ODR_26,   /** 26 Hz */
-    G_ODR_52,   /** 52 Hz */
-    G_ODR_104,  /** 104 Hz */
-    G_ODR_208,  /** 208 Hz */
-    G_ODR_416,  /** 416 Hz */
-    G_ODR_833,  /** 833 Hz */
-    G_ODR_1666, /** 1666 Hz */
-    G_ODR_3332, /** 3332 Hz */
-    G_ODR_6664, /** 6644 Hz */
+    G_ODR_12_5 = 0x10, /** 12.5 Hz */
+    G_ODR_26 = 0x20,   /** 26 Hz */
+    G_ODR_52 = 0x30,   /** 52 Hz */
+    G_ODR_104 = 0x40,  /** 104 Hz */
+    G_ODR_208 = 0x50,  /** 208 Hz */
+    G_ODR_416 = 0x60,  /** 416 Hz */
+    G_ODR_833 = 0x70,  /** 833 Hz */
+    G_ODR_1666 = 0x80, /** 1666 Hz */
+    G_ODR_3332 = 0x90, /** 3332 Hz */
+    G_ODR_6664 = 0xA0, /** 6644 Hz */
 } gyro_odr_e;
 
 int lsm6dso32_reset(SensorLocation const *loc);


### PR DESCRIPTION
This PR implements a more specific interface for the LSM6DSO32 IMU sensor and removes its dependency on the old sensor interface (except for SensorLocation).