### PR TITLE
Use periodic messages on M10SPG

### DIFF
--- a/src/collectors/m10spg_clctr.c
+++ b/src/collectors/m10spg_clctr.c
@@ -42,11 +42,11 @@ void *m10spg_collector(void *args) {
             continue;
         }
     } while (err != EOK);
-
+    UBXNavPVTPayload payload;
     for (;;) {
-        UBXNavPVTPayload payload;
+        size_t payload_size = sizeof(payload);
         // Clear out our read buffer (ask for nothing back)
-        err = m10spg_read(&ctx, UBX_MSG_NONE, (uint8_t *)&payload, sizeof(payload));
+        err = m10spg_read(&ctx, UBX_MSG_NONE, (uint8_t *)&payload, &payload_size);
         // TODO - Check err
         // Wait until the next navigation epoch
         m10spg_sleep_epoch(&ctx);

--- a/src/collectors/m10spg_clctr.c
+++ b/src/collectors/m10spg_clctr.c
@@ -46,7 +46,11 @@ void *m10spg_collector(void *args) {
             log_print(stderr, LOG_ERROR, "Could not send command to M10SPG: %s", strerror(err));
             wait_for_meas(NULL);
             continue;
-        } else if (!(payload.flags & 0x1) || payload.fixType == GPS_NO_FIX) {
+        }
+        fetcher_log(stderr, LOG_INFO, "M10SPG current fix is: %d", payload.fixType);
+
+        // Skip this payload if the fix isn't valid
+        if (!(payload.flags & GNSS_FIX_OK)) {
             // Don't bother looking at data if it is going to be invalid
             log_print(stderr, LOG_WARN, "M10SPG fix is invalid or no-fix, skipping this payload ");
             wait_for_meas(&payload);
@@ -71,6 +75,8 @@ void *m10spg_collector(void *args) {
             send_msg(sensor_q, msg, 3);
             break;
         case GPS_TIME_ONLY:
+            break;
+        case GPS_NO_FIX:
             break;
         default:
             break;

--- a/src/collectors/m10spg_clctr.c
+++ b/src/collectors/m10spg_clctr.c
@@ -48,7 +48,7 @@ void *m10spg_collector(void *args) {
     for (;;) {
         // Clear out our read buffer (ask for nothing back)
         m10spg_read(&ctx, UBX_MSG_NONE, &msg, sizeof(payload));
-        m10spg_sleep_epoch(&ctx);
+        m10spg_sleep_epoch();
     }
     log_print(stderr, LOG_ERROR, "M10SPG exited unexpectedly: %s", strerror(err));
     return (void *)((uint64_t)err);

--- a/src/collectors/m10spg_clctr.c
+++ b/src/collectors/m10spg_clctr.c
@@ -56,7 +56,6 @@ void *m10spg_collector(void *args) {
 
 /** A function implementing the M10SPGMessageHandler definition, for handling PVT messages (not thread safe currently)*/
 int m10spg_pvt_handler(UBXFrame *msg) {
-    // TODO - double check the type ourselves
     if (!m10spg_is_type(msg, UBX_MSG_NAV_PVT)) {
         log_print(stderr, LOG_ERROR, "Handler was given a type it cannot handle, configuration error");
         return -1;

--- a/src/drivers/m10spg/m10spg.c
+++ b/src/drivers/m10spg/m10spg.c
@@ -50,7 +50,7 @@ static const UBXFrame PREMADE_MESSAGES[] = {
     [UBX_NAV_VELNED] = {.header = {.class = 0x01, .id = 0x12, .length = 0x00}, .checksum_a = 0x13, .checksum_b = 0x3a},
     [UBX_NAV_STAT] = {.header = {.class = 0x01, .id = 0x03, .length = 0x00}, .checksum_a = 0x04, .checksum_b = 0x0d},
     [UBX_MON_VER] = {.header = {.class = 0x0A, .id = 0x04, .length = 0x00}, .checksum_a = 0x0E, .checksum_b = 0x34},
-    [UBX_NAV_PVT] = {0},
+    [UBX_NAV_PVT] = {.header = {.class = 0x01, .id = 0x07, .length = 0x00}, .checksum_a = 0x08, .checksum_b = 0x19},
 };
 
 /**

--- a/src/drivers/m10spg/m10spg.c
+++ b/src/drivers/m10spg/m10spg.c
@@ -209,6 +209,9 @@ static int recv_message(const SensorLocation *loc, UBXFrame *msg, uint16_t max_p
             return_err(err);
             // Read in the checksums (assume contiguous)
             err = read_bytes(loc, &msg->checksum_a, 2);
+            if (!checksum_is_valid(msg)) {
+                return EBADMSG;
+            }
             return err;
         } else {
             return EBADMSG;

--- a/src/drivers/m10spg/m10spg.c
+++ b/src/drivers/m10spg/m10spg.c
@@ -128,7 +128,7 @@ static inline int checksum_is_valid(UBXFrame *msg) {
 /**
  * Helper function to sleep this thread until it's likely there will be a new payload in the data buffer soon
  */
-void m10spg_sleep_epoch() {
+void m10spg_sleep_epoch(void) {
     // Sleep the time between measurements, which should be roughly the time between packages
     usleep(UBX_NOMINAL_MEASUREMENT_RATE * 1000);
 }

--- a/src/drivers/m10spg/m10spg.c
+++ b/src/drivers/m10spg/m10spg.c
@@ -127,9 +127,8 @@ static inline int checksum_is_valid(UBXFrame *msg) {
 
 /**
  * Helper function to sleep this thread until it's likely there will be a new payload in the data buffer soon
- * @param ctx The context of the m10spg sensor that should be waited for
  */
-void m10spg_sleep_epoch(M10SPGContext *ctx) {
+void m10spg_sleep_epoch() {
     // Sleep the time between measurements, which should be roughly the time between packages
     usleep(UBX_NOMINAL_MEASUREMENT_RATE * 1000);
 }
@@ -141,7 +140,7 @@ void m10spg_sleep_epoch(M10SPGContext *ctx) {
  * @param nbytes The number of bytes to read into the buffer
  * @return int The error status of the call. EOK if successful.
  */
-int read_bytes(const SensorLocation *loc, void *buf, size_t nbytes) {
+static int read_bytes(const SensorLocation *loc, void *buf, size_t nbytes) {
     i2c_recv_t header = {.stop = 1};
     header.slave = loc->addr;
     header.len = nbytes;

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -20,9 +20,22 @@ typedef enum {
     UBX_NAV_STAT,   /**< GPS status information about fix, fix type */
     UBX_MON_VER,    /**< Firmware version information */
     UBX_NAV_PVT,    /**< Position, velocity, time information, it is reccomended to use this message */
-} M10SPG_cmd_t;
+} M10SPGMessageType;
+
+/**
+ * A pointer to a function that will recieve a buffer containing a populated message containing a complete payload and
+ * the type of the message that was recieved. The handler is reponsible for using the data, after which it will be
+ * discarded
+ *
+ * @param msg The message that was last read from the gps and which now needs to be consumed
+ * @param type The type of msg (containing the same information as the class and id fields)
+ * @return 0 if the message was handled successfully, -1 if there was an error processing the message
+ */
+typedef int (*M10SPGMessageHandler)(UBXFrame *msg, M10SPGMessageType type);
 
 int m10spg_open(const SensorLocation *loc);
-int m10spg_read(const SensorLocation *loc, M10SPG_cmd_t command, void *response, size_t size);
+int m10spg_read(const SensorLocation *loc, M10SPGMessageType msg_type, uint8_t *buf, size_t size);
+int m10spg_register_periodic(const SensorLocation *loc, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
 void wait_for_meas(UBXNavPVTPayload *payload);
+
 #endif // _MAXM10S_

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -9,6 +9,7 @@
 #define _MAXM10S_
 
 #include "../sensor_api.h"
+#include "ubx_def.h"
 #include <stdint.h>
 
 /** An enum representing the commands that can be used for polling M10SPG data. */
@@ -18,9 +19,10 @@ typedef enum {
     UBX_NAV_VELNED, /**< Velocity and heading information */
     UBX_NAV_STAT,   /**< GPS status information about fix, fix type */
     UBX_MON_VER,    /**< Firmware version information */
+    UBX_NAV_PVT,    /**< Position, velocity, time information, it is reccomended to use this message */
 } M10SPG_cmd_t;
 
 int m10spg_open(const SensorLocation *loc);
-int m10spg_send_command(const SensorLocation *loc, M10SPG_cmd_t command, void *response, size_t size);
-
+int m10spg_read(const SensorLocation *loc, M10SPG_cmd_t command, void *response, size_t size);
+void wait_for_meas(UBXNavPVTPayload *payload);
 #endif // _MAXM10S_

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -12,14 +12,17 @@
 #include "ubx_def.h"
 #include <stdint.h>
 
-/** An enum representing the commands that can be used for polling M10SPG data. */
+/** An enum representing the commands that can be used for reading from the M10SPG, where the value of the enum
+ * represents the class and id, in the high and low bytes of a uint16, respectively */
 typedef enum {
-    UBX_NAV_UTC,    /**< UTC time information, recieved formatted as a human readable date */
-    UBX_NAV_POSLLH, /**< Latitude and longitude information, along with altitude */
-    UBX_NAV_VELNED, /**< Velocity and heading information */
-    UBX_NAV_STAT,   /**< GPS status information about fix, fix type */
-    UBX_MON_VER,    /**< Firmware version information */
-    UBX_NAV_PVT,    /**< Position, velocity, time information, it is reccomended to use this message */
+    UBX_NO_MESSAGE = 0x0000, /**< Read no message */
+    UBX_ANY = 0xFFFF,        /**< Read any message */
+    UBX_NAV_UTC = 0x0121,    /**< Read UTC time information, recieved formatted as a human readable date */
+    UBX_NAV_POSLLH = 0x0102, /**< Read Latitude and longitude information, along with altitude */
+    UBX_NAV_VELNED = 0x0112, /**< Read Velocity and heading information */
+    UBX_NAV_STAT = 0x0103,   /**< Read GPS status information about fix, fix type */
+    UBX_MON_VER = 0x0A04,    /**< Read Firmware version information */
+    UBX_NAV_PVT = 0x0107,    /**< Read Position, velocity, time information (reccomended) */
 } M10SPGMessageType;
 
 /**

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -54,6 +54,6 @@ int m10spg_open(M10SPGContext *ctx, SensorLocation *loc);
 int m10spg_read(M10SPGContext *ctx, M10SPGMessageType msg_type, UBXFrame *recv, size_t size);
 int m10spg_register_periodic(M10SPGContext *ctx, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
 int m10spg_is_type(UBXFrame *msg, M10SPGMessageType type);
-void m10spg_sleep_epoch();
+void m10spg_sleep_epoch(void);
 
 #endif // _MAXM10S_

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -23,6 +23,7 @@ typedef enum {
     UBX_NAV_STAT = 0x0103,   /**< Read GPS status information about fix, fix type */
     UBX_MON_VER = 0x0A04,    /**< Read Firmware version information */
     UBX_NAV_PVT = 0x0107,    /**< Read Position, velocity, time information (reccomended) */
+    UBX_ACK = 0x1,
 } M10SPGMessageType;
 
 /**
@@ -48,8 +49,8 @@ typedef struct {
 } M10SPGContext;
 
 int m10spg_open(M10SPGContext *ctx, SensorLocation *loc);
-int m10spg_read(const M10SPGContext *ctx, M10SPGMessageType msg_type, uint8_t *buf, size_t size);
-int m10spg_register_periodic(const M10SPGContext *ctx, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
+int m10spg_read(M10SPGContext *ctx, M10SPGMessageType msg_type, uint8_t *buf, size_t size);
+int m10spg_register_periodic(M10SPGContext *ctx, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
 void wait_for_meas(M10SPGContext *ctx);
 
 #endif // _MAXM10S_

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -15,17 +15,18 @@
 /** An enum representing the commands that can be used for reading from the M10SPG, where the value of the enum
  * represents the class and id, in the high and low bytes of a uint16, respectively */
 typedef enum {
-    UBX_MSG_NONE = 0X00, /**< No message */
-    UBX_MSG_ANY,         /**< Any message */
-    UBX_MSG_ACK,         /**< Acknowledgment message */
-    UBX_MSG_NACK,        /**< Non-acknowledgement message */
-    UBX_MSG_ACK_NACK,    /**< Acknowledgement or non-acknowledgement message */
-    UBX_MSG_NAV_UTC,     /**< UTC time information, recieved formatted as a human readable date */
-    UBX_MSG_NAV_POSLLH,  /**< Latitude and longitude information, along with altitude */
-    UBX_MSG_NAV_VELNED,  /**< Velocity and heading information */
-    UBX_MSG_NAV_STAT,    /**< GPS status information about fix, fix type */
-    UBX_MSG_MON_VER,     /**< Firmware version information */
-    UBX_MSG_NAV_PVT,     /**< Position, velocity, time information (reccomended) */
+    UBX_MSG_NONE = 0X00,       /**< No message */
+    UBX_MSG_ANY = 0x01,        /**< Any message */
+    UBX_MSG_ACK = 0x02,        /**< Acknowledgment message */
+    UBX_MSG_NACK = 0x03,       /**< Non-acknowledgement message */
+    UBX_MSG_ACK_NACK = 0x04,   /**< Acknowledgement or non-acknowledgement message */
+    UBX_MSG_NAV_UTC = 0x05,    /**< UTC time information, recieved formatted as a human readable date */
+    UBX_MSG_NAV_POSLLH = 0x06, /**< Latitude and longitude information, along with altitude */
+    UBX_MSG_NAV_VELNED = 0x07, /**< Velocity and heading information */
+    UBX_MSG_NAV_STAT = 0x08,   /**< GPS status information about fix, fix type */
+    UBX_MSG_MON_VER = 0x09,    /**< Firmware version information */
+    UBX_MSG_NAV_PVT = 0x0a,    /**< Position, velocity, time information (reccomended) */
+    UBX_MSG_RST = 0x0b,        /**< Reciever reset message */
 } M10SPGMessageType;
 
 /**
@@ -51,7 +52,7 @@ typedef struct {
 } M10SPGContext;
 
 int m10spg_open(M10SPGContext *ctx, SensorLocation *loc);
-int m10spg_read(M10SPGContext *ctx, M10SPGMessageType msg_type, uint8_t *buf, size_t size);
+M10SPGMessageType m10spg_read(M10SPGContext *ctx, M10SPGMessageType msg_type, uint8_t *buf, size_t *size);
 int m10spg_register_periodic(M10SPGContext *ctx, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
 M10SPGMessageType m10spg_get_payload_type(UBXFrame *msg);
 void m10spg_sleep_epoch(M10SPGContext *ctx);

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -15,15 +15,17 @@
 /** An enum representing the commands that can be used for reading from the M10SPG, where the value of the enum
  * represents the class and id, in the high and low bytes of a uint16, respectively */
 typedef enum {
-    UBX_NO_MESSAGE = 0x0000, /**< Read no message */
-    UBX_ANY = 0xFFFF,        /**< Read any message */
-    UBX_NAV_UTC = 0x0121,    /**< Read UTC time information, recieved formatted as a human readable date */
-    UBX_NAV_POSLLH = 0x0102, /**< Read Latitude and longitude information, along with altitude */
-    UBX_NAV_VELNED = 0x0112, /**< Read Velocity and heading information */
-    UBX_NAV_STAT = 0x0103,   /**< Read GPS status information about fix, fix type */
-    UBX_MON_VER = 0x0A04,    /**< Read Firmware version information */
-    UBX_NAV_PVT = 0x0107,    /**< Read Position, velocity, time information (reccomended) */
-    UBX_ACK = 0x1,
+    UBX_MSG_NONE = 0X00, /**< No message */
+    UBX_MSG_ANY,         /**< Any message */
+    UBX_MSG_ACK,         /**< Acknowledgment message */
+    UBX_MSG_NACK,        /**< Non-acknowledgement message */
+    UBX_MSG_ACK_NACK,    /**< Acknowledgement or non-acknowledgement message */
+    UBX_MSG_NAV_UTC,     /**< UTC time information, recieved formatted as a human readable date */
+    UBX_MSG_NAV_POSLLH,  /**< Latitude and longitude information, along with altitude */
+    UBX_MSG_NAV_VELNED,  /**< Velocity and heading information */
+    UBX_MSG_NAV_STAT,    /**< GPS status information about fix, fix type */
+    UBX_MSG_MON_VER,     /**< Firmware version information */
+    UBX_MSG_NAV_PVT,     /**< Position, velocity, time information (reccomended) */
 } M10SPGMessageType;
 
 /**
@@ -37,7 +39,7 @@ typedef enum {
  */
 typedef int (*M10SPGMessageHandler)(UBXFrame *msg, M10SPGMessageType type);
 
-#define MAX_PERIODIC_MESSAGES 3
+#define MAX_PERIODIC_MESSAGES 1
 
 /** A struct that describes a M10SPG sensor */
 typedef struct {
@@ -51,6 +53,7 @@ typedef struct {
 int m10spg_open(M10SPGContext *ctx, SensorLocation *loc);
 int m10spg_read(M10SPGContext *ctx, M10SPGMessageType msg_type, uint8_t *buf, size_t size);
 int m10spg_register_periodic(M10SPGContext *ctx, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
-void wait_for_meas(M10SPGContext *ctx);
+M10SPGMessageType m10spg_get_payload_type(UBXFrame *msg);
+void m10spg_sleep_epoch(M10SPGContext *ctx);
 
 #endif // _MAXM10S_

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -33,9 +33,20 @@ typedef enum {
  */
 typedef int (*M10SPGMessageHandler)(UBXFrame *msg, M10SPGMessageType type);
 
-int m10spg_open(const SensorLocation *loc);
-int m10spg_read(const SensorLocation *loc, M10SPGMessageType msg_type, uint8_t *buf, size_t size);
-int m10spg_register_periodic(const SensorLocation *loc, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
-void wait_for_meas(UBXNavPVTPayload *payload);
+#define MAX_PERIODIC_MESSAGES 3
+
+/** A struct that describes a M10SPG sensor */
+typedef struct {
+    const SensorLocation *loc; /**< The location of this sensor on the I2C bus */
+    struct {
+        M10SPGMessageType type;       /**< The type of message that this handler takes */
+        M10SPGMessageHandler handler; /**< The function to call when finding a message of the specified type */
+    } handlers[MAX_PERIODIC_MESSAGES];
+} M10SPGContext;
+
+int m10spg_open(M10SPGContext *ctx, SensorLocation *loc);
+int m10spg_read(const M10SPGContext *ctx, M10SPGMessageType msg_type, uint8_t *buf, size_t size);
+int m10spg_register_periodic(const M10SPGContext *ctx, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
+void wait_for_meas(M10SPGContext *ctx);
 
 #endif // _MAXM10S_

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -15,12 +15,12 @@
 /** An enum representing the commands that can be used for reading from the M10SPG, where the value of the enum
  * represents the class and id, in the high and low bytes of a uint16, respectively */
 typedef enum {
-    UBX_MSG_NONE = 0X00,       /**< No message */
-    UBX_MSG_ANY = 0x01,        /**< Any message */
-    UBX_MSG_ACK = 0x02,        /**< Acknowledgment message */
-    UBX_MSG_NACK = 0x03,       /**< Non-acknowledgement message */
-    UBX_MSG_ACK_NACK = 0x04,   /**< Acknowledgement or non-acknowledgement message */
-    UBX_MSG_NAV_UTC = 0x05,    /**< UTC time information, recieved formatted as a human readable date */
+    UBX_MSG_NONE = 0x00,     /**< No message (not a real message type) */
+    UBX_MSG_ANY = 0x01,      /**< Any message (not a real message type) */
+    UBX_MSG_ACK = 0x02,      /**< Acknowledgment message */
+    UBX_MSG_NACK = 0x03,     /**< Non-acknowledgement message */
+    UBX_MSG_ACK_NACK = 0x04, /**< Either the acknowledgement or non-acknowledgement message (not a real message type) */
+    UBX_MSG_NAV_UTC = 0x05,  /**< UTC time information, recieved formatted as a human readable date */
     UBX_MSG_NAV_POSLLH = 0x06, /**< Latitude and longitude information, along with altitude */
     UBX_MSG_NAV_VELNED = 0x07, /**< Velocity and heading information */
     UBX_MSG_NAV_STAT = 0x08,   /**< GPS status information about fix, fix type */
@@ -35,10 +35,9 @@ typedef enum {
  * discarded
  *
  * @param msg The message that was last read from the gps and which now needs to be consumed
- * @param type The type of msg (containing the same information as the class and id fields)
  * @return 0 if the message was handled successfully, -1 if there was an error processing the message
  */
-typedef int (*M10SPGMessageHandler)(UBXFrame *msg, M10SPGMessageType type);
+typedef int (*M10SPGMessageHandler)(UBXFrame *msg);
 
 #define MAX_PERIODIC_MESSAGES 1
 
@@ -52,9 +51,9 @@ typedef struct {
 } M10SPGContext;
 
 int m10spg_open(M10SPGContext *ctx, SensorLocation *loc);
-M10SPGMessageType m10spg_read(M10SPGContext *ctx, M10SPGMessageType msg_type, uint8_t *buf, size_t *size);
+int m10spg_read(M10SPGContext *ctx, M10SPGMessageType msg_type, UBXFrame *recv, size_t size);
 int m10spg_register_periodic(M10SPGContext *ctx, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
-M10SPGMessageType m10spg_get_payload_type(UBXFrame *msg);
+int m10spg_is_type(UBXFrame *msg, M10SPGMessageType type);
 void m10spg_sleep_epoch(M10SPGContext *ctx);
 
 #endif // _MAXM10S_

--- a/src/drivers/m10spg/m10spg.h
+++ b/src/drivers/m10spg/m10spg.h
@@ -54,6 +54,6 @@ int m10spg_open(M10SPGContext *ctx, SensorLocation *loc);
 int m10spg_read(M10SPGContext *ctx, M10SPGMessageType msg_type, UBXFrame *recv, size_t size);
 int m10spg_register_periodic(M10SPGContext *ctx, M10SPGMessageHandler handler, M10SPGMessageType msg_type);
 int m10spg_is_type(UBXFrame *msg, M10SPGMessageType type);
-void m10spg_sleep_epoch(M10SPGContext *ctx);
+void m10spg_sleep_epoch();
 
 #endif // _MAXM10S_

--- a/src/drivers/m10spg/ubx_def.h
+++ b/src/drivers/m10spg/ubx_def.h
@@ -65,6 +65,21 @@ typedef struct {
     uint8_t config_items[MAX_VALSET_ITEM_BYTES]; /** An array of keys and value pairs */
 } UBXValsetPayload;
 
+/** A configuration key for enabling or disabling output of NMEA messages on I2C */
+#define NMEA_I2C_OUTPUT_CONFIG_KEY 0x10720002
+
+/** A configuration key for enabling or disabling input of poll requests for NMEA messages on I2C */
+#define NMEA_I2C_INPUT_CONFIG_KEY 0x10710002
+
+/** A configuration key for selecting the platform model of the reciever */
+#define DYNMODEL_CONFIG_KEY 0x20110021
+
+/** A configuration key for enabling or disabling the BeiDou satellites */
+#define BSD_SIGNAL_CONFIG_KEY 0x10310022
+
+/** A configuration key for selecting the number of milliseconds between measurements */
+#define MEASUREMENT_RATE_CONFIG_KEY 0x30210001
+
 /** A struct representing the UBX-NAV-STAT (navigation status) payload */
 typedef struct {
     uint32_t iTOW;   /**< The GPS time of week of the navigation epoch that created this payload */

--- a/src/drivers/m10spg/ubx_def.h
+++ b/src/drivers/m10spg/ubx_def.h
@@ -150,6 +150,54 @@ typedef struct {
     uint32_t cAcc;   /**< Course/heading accuracy estimate, in 0.00001 * degrees */
 } UBXNavVelocityPayload;
 
+/** A payload containing position, velocity, and time information. This payload is reccomended by UBlox over the other
+ * payloads containing position, velocity, or time information (they are only retained for backwards compatability)*/
+typedef struct {
+    uint32_t iTOW; /**< The GPS time of week of the navigation epoch that created this payload */
+    // Time information
+    uint16_t year; /**< A year from 1999 to 2099 (this can be incorrect if the chip was manufactured 20+ years ago) */
+    uint8_t month; /**< A month from 1 to 12 */
+    uint8_t day;   /**< Day of the month in the range 1 to 31 */
+    uint8_t hour;  /**< Hour of the day in the range 0 to 23 */
+    uint8_t min;   /**< Minute of the hour in the range 0 to 59 */
+    uint8_t sec;   /**< Second of the minute in the range 0 to 60 */
+    uint8_t valid; /**< Flags that describe if this time information is valid (see the interface description) */
+    uint32_t tAcc; /**< A time accuracy measurement for the UTC time, in nanoseconds */
+    int32_t nano;  /**< A time correction for the date that follows in this payload, in nanoseconds */
+
+    // Status information
+    uint8_t fixType; /**< The type of fix */
+    uint8_t flags;   /**< Fix status flags */
+    uint8_t flags2;  /**< Additional flags for UTC time validity */
+    uint8_t numSV;   /**< The number of satellites used in solution */
+
+    // Position information
+    int32_t lon;    /**< Longitude, in 0.0000001 * degrees */
+    int32_t lat;    /**< Latitude, in 0.0000001 * degrees */
+    int32_t height; /**< Height above ellipsoid in millimeters */
+    int32_t hMSL;   /**< Height above mean sea level in millimeters */
+    uint32_t hAcc;  /**< Horizontal accuracy measurement in millimeters */
+    uint32_t vAcc;  /**< Vertical accuracy measurement in millimeters */
+
+    // Velocity information
+    int32_t velN;     /**< North velocity component, in cm/s */
+    int32_t velE;     /**< East velocity component, in cm/s */
+    int32_t velD;     /**< Down velocity component, in cm/s */
+    int32_t gSpeed;   /**< Ground speed (2-D), in cm/s */
+    int32_t headMot;  /**< Heading of motion (2-D), in 1e-5 degrees */
+    uint32_t sAcc;    /**< Speed accuracy estimate, in cm/s */
+    uint32_t headAcc; /**< Course/heading accuracy estimate, in 1e-5 degrees */
+
+    uint16_t pDOP;   /**< Position dilution of precision (3D) in increments of 0.01, < 1 is ideal, > 20 is useless  */
+    uint16_t flags3; /**< Additional flags related to position accuracy */
+
+    // Extra information
+    uint8_t reserved[4]; /**< Reserved bytes */
+    int32_t headVeh;     /**< Heading of vehicle (2D), not enabled on the M10SPG */
+    int16_t magDec;      /**< Magnetic declination, not supported on M10SPG */
+    uint16_t magAcc;     /**< Magnetic declination accuracy, not supported on M10SPG*/
+} UBXNavPVTPayload;
+
 /** A struct representing the UBX-ACK-ACK/UBX-ACK-NACK (acknowledgement) payload */
 typedef struct {
     uint8_t clsId; /**< The class ID of the acknowledged or not acknowledged message */

--- a/src/drivers/m10spg/ubx_def.h
+++ b/src/drivers/m10spg/ubx_def.h
@@ -54,6 +54,22 @@ typedef struct {
     uint8_t flags; /**< Flags that describe if this time information is valid (see the interface description) */
 } UBXUTCPayload;
 
+typedef enum {
+    UBX_HARD_RESET = 0x00,      /**< Hardware reset (watchdog), immediate */
+    UBX_SOFT_RESET = 0x01,      /**< Controlled software reset (clears RAM) */
+    UBX_SOFT_GNSS_RESET = 0x02, /**< Controlled software reset, GNSS only */
+    UBX_HARD_WDT_RESET = 0x04,  /**< Hardware reset (watchdog), after shutdown */
+    UBX_STOP_GNSS = 0x08,       /** Controlled GNSS stop */
+    UBX_START_GNSS = 0x09,      /**< Controlled GNSS start */
+} UBXResetMode;
+
+/** A struct representing the UBX-CFG-RST (reset reciever) payload */
+typedef struct {
+    uint8_t navBbrMask[2]; /**< Bit fields that select what BBR data to clear (leave as 0 for a hot start) */
+    uint8_t resetMode;     /**< The type of reset to perform, of type UBXResetMode */
+    uint8_t reserved;      /**< Reserved bytes */
+} UBXConfigResetPayload;
+
 /** Max bytes to be used for valset payload items (limit of 64 items per message) */
 #define MAX_VALSET_ITEM_BYTES 128
 

--- a/src/drivers/m10spg/ubx_def.h
+++ b/src/drivers/m10spg/ubx_def.h
@@ -88,13 +88,22 @@ typedef struct {
 #define NMEA_I2C_INPUT_CONFIG_KEY 0x10710002
 
 /** A configuration key for selecting the platform model of the reciever */
-#define DYNMODEL_CONFIG_KEY 0x20110021
+#define UBX_DYNMODEL_CONFIG_KEY 0x20110021
+
+/** The confirmation value for the platform model that corresponds to an airborne vehicle doing <4G of acceleration */
+#define UBX_DYNMODEL_AIR_4G 8
+
+/** The nominal time between gps measurements in milliseconds */
+#define UBX_NOMINAL_MEASUREMENT_RATE 300
+
+/** A configuration key for enabling or disabling periodic message output of the UBX-NAV-PVT message */
+#define UBX_MSGOUT_I2C_NAV_PVT 0x20910006
 
 /** A configuration key for enabling or disabling the BeiDou satellites */
-#define BSD_SIGNAL_CONFIG_KEY 0x10310022
+#define UBX_BSD_SIGNAL_CONFIG_KEY 0x10310022
 
 /** A configuration key for selecting the number of milliseconds between measurements */
-#define MEASUREMENT_RATE_CONFIG_KEY 0x30210001
+#define UBX_MEAS_RATE_CONFIG_KEY 0x30210001
 
 /** A struct representing the UBX-NAV-STAT (navigation status) payload */
 typedef struct {

--- a/src/drivers/m10spg/ubx_def.h
+++ b/src/drivers/m10spg/ubx_def.h
@@ -198,6 +198,11 @@ typedef struct {
     uint16_t magAcc;     /**< Magnetic declination accuracy, not supported on M10SPG*/
 } UBXNavPVTPayload;
 
+/** Bit masks for the "flags" member of the UBX-NAV-PVT message */
+typedef enum {
+    GNSS_FIX_OK = 0x01, /**< A single bit flag, the result of this mask is a 1 if the current fix is valid */
+} UBXFlagsMasks;
+
 /** A struct representing the UBX-ACK-ACK/UBX-ACK-NACK (acknowledgement) payload */
 typedef struct {
     uint8_t clsId; /**< The class ID of the acknowledged or not acknowledged message */


### PR DESCRIPTION
Periodic messages offer a number of benefits over regular polling
- No time waiting for a response
- Output of message as soon as they are available
- Less busy reading
- Easier to configure output of multiple message types

Also made a couple other changes
- Added a context structure for the gps
- Added a function for also sending a valset message to simplify using them
- Removed the timeout for read, the sensor will attempt to read a message 10 times, evenly spaced, instead of checking the monotonic clock
- Added a way to check if a message is of a certain type. The array of message headers will be useful for a polling interface in the future, if that's required.